### PR TITLE
feat: add premium animated sync UX

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,8 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::io::{IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -31,6 +31,10 @@ enum Commands {
         quiet: bool,
         #[arg(long)]
         json: bool,
+        #[arg(long)]
+        plain: bool,
+        #[arg(long)]
+        verbose: bool,
     },
     InstallHooks {
         #[arg(long, default_value = "skills.config.yaml")]
@@ -124,7 +128,15 @@ struct Report {
 }
 
 const BANNER: &str = r#"
-              カセット | KASETTO
+╔════════════════════════════════════════════════════════════╗
+║  ██╗  ██╗ █████╗ ███████╗███████╗████████╗████████╗ ██████╗ ║
+║  ██║ ██╔╝██╔══██╗██╔════╝██╔════╝╚══██╔══╝╚══██╔══╝██╔═══██╗║
+║  █████╔╝ ███████║███████╗█████╗     ██║      ██║   ██║   ██║║
+║  ██╔═██╗ ██╔══██║╚════██║██╔══╝     ██║      ██║   ██║   ██║║
+║  ██║  ██╗██║  ██║███████║███████╗   ██║      ██║   ╚██████╔╝║
+║  ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝╚══════╝   ╚═╝      ╚═╝    ╚═════╝ ║
+║                        カセット  |  kasetto                   ║
+╚════════════════════════════════════════════════════════════╝
 "#;
 
 fn main() -> Result<()> {
@@ -134,13 +146,17 @@ fn main() -> Result<()> {
         dry_run: false,
         quiet: false,
         json: false,
+        plain: false,
+        verbose: false,
     }) {
         Commands::Sync {
             config,
             dry_run,
             quiet,
             json,
-        } => run_sync(&config, dry_run, quiet, json),
+            plain,
+            verbose,
+        } => run_sync(&config, dry_run, quiet, json, plain, verbose),
         Commands::InstallHooks {
             config,
             timeout_seconds,
@@ -172,18 +188,29 @@ fn load_config_any(config_path: &str) -> Result<(Config, PathBuf, String)> {
     Ok((cfg, cfg_dir, cfg_abs.to_string_lossy().to_string()))
 }
 
-fn run_sync(config_path: &str, dry_run: bool, quiet: bool, as_json: bool) -> Result<()> {
-    let animate = animations_enabled(quiet, as_json);
+fn run_sync(
+    config_path: &str,
+    dry_run: bool,
+    quiet: bool,
+    as_json: bool,
+    plain: bool,
+    verbose: bool,
+) -> Result<()> {
+    let animate = animations_enabled(quiet, as_json, plain);
     if !quiet && !as_json {
-        print!("{}", BANNER);
+        if plain {
+            println!("kasetto | カセット");
+        } else {
+            print!("{}", BANNER);
+        }
     }
 
-    let (cfg, cfg_dir, cfg_label) = with_spinner(animate, "Loading config", || {
+    let (cfg, cfg_dir, cfg_label) = with_spinner(animate, plain, "Loading config", || {
         load_config_any(config_path)
     })?;
     let destination = resolve_path(&cfg_dir, &cfg.destination);
     if !dry_run {
-        with_spinner(animate, "Preparing destination", || {
+        with_spinner(animate, plain, "Preparing destination", || {
             fs::create_dir_all(&destination)?;
             Ok(())
         })?;
@@ -197,14 +224,16 @@ fn run_sync(config_path: &str, dry_run: bool, quiet: bool, as_json: bool) -> Res
     for (i, src) in cfg.skills.iter().enumerate() {
         let stage = std::env::temp_dir().join(format!("kasetto-{}-{}", now_unix(), i));
         let source_step = format!("Syncing source {}", src.source);
-        match with_spinner(animate, &source_step, || materialize_source(src, &cfg_dir, &stage)) {
+        match with_spinner(animate, plain, &source_step, || {
+            materialize_source(src, &cfg_dir, &stage)
+        }) {
             Ok((root, rev, available)) => {
                 let targets = select_targets(&src.skills, &available)?;
                 for (skill_name, skill_path) in targets {
                     let key = format!("{}::{}", src.source, skill_name);
                     desired_keys.insert(key.clone());
                     let hash_step = format!("Hashing {}", skill_name);
-                    let hash = with_spinner(animate, &hash_step, || hash_dir(&skill_path))?;
+                    let hash = with_spinner(animate, plain, &hash_step, || hash_dir(&skill_path))?;
                     let dest = destination.join(&skill_name);
                     if let Some(prev) = state.skills.get(&key) {
                         if prev.hash == hash && dest.exists() {
@@ -240,7 +269,7 @@ fn run_sync(config_path: &str, dry_run: bool, quiet: bool, as_json: bool) -> Res
                     }
 
                     let copy_step = format!("Applying {}", skill_name);
-                    with_spinner(animate, &copy_step, || copy_dir(&skill_path, &dest))?;
+                    with_spinner(animate, plain, &copy_step, || copy_dir(&skill_path, &dest))?;
                     let status = if state.skills.contains_key(&key) {
                         summary.updated += 1;
                         "updated"
@@ -310,7 +339,7 @@ fn run_sync(config_path: &str, dry_run: bool, quiet: bool, as_json: bool) -> Res
 
     if !dry_run {
         state.last_run = Some(now_iso());
-        with_spinner(animate, "Saving state", || save_state(&state))?;
+        with_spinner(animate, plain, "Saving state", || save_state(&state))?;
     }
 
     let report = Report {
@@ -321,7 +350,7 @@ fn run_sync(config_path: &str, dry_run: bool, quiet: bool, as_json: bool) -> Res
         summary,
         actions,
     };
-    let report_path = with_spinner(animate, "Writing report", || save_report(&report))?;
+    let report_path = with_spinner(animate, plain, "Writing report", || save_report(&report))?;
 
     if as_json {
         println!("{}", serde_json::to_string_pretty(&report)?);
@@ -335,6 +364,20 @@ fn run_sync(config_path: &str, dry_run: bool, quiet: bool, as_json: bool) -> Res
             report.summary.failed
         );
         println!("Report: {}", report_path.display());
+
+        if verbose {
+            println!("\nActions:");
+            for a in &report.actions {
+                let status = status_chip(&a.status, plain);
+                let src = a.source.as_deref().unwrap_or("-");
+                let skill = a.skill.as_deref().unwrap_or("-");
+                if let Some(err) = &a.error {
+                    println!("  {} {} :: {} -> {}", status, src, skill, err);
+                } else {
+                    println!("  {} {} :: {}", status, src, skill);
+                }
+            }
+        }
     }
 
     if report.summary.failed > 0 {
@@ -343,11 +386,16 @@ fn run_sync(config_path: &str, dry_run: bool, quiet: bool, as_json: bool) -> Res
     Ok(())
 }
 
-fn animations_enabled(quiet: bool, as_json: bool) -> bool {
-    !quiet && !as_json && std::io::stderr().is_terminal()
+fn animations_enabled(quiet: bool, as_json: bool, plain: bool) -> bool {
+    !quiet && !as_json && !plain && std::io::stderr().is_terminal()
 }
 
-fn with_spinner<T, F>(enabled: bool, label: impl Into<String>, operation: F) -> Result<T>
+fn with_spinner<T, F>(
+    enabled: bool,
+    plain: bool,
+    label: impl Into<String>,
+    operation: F,
+) -> Result<T>
 where
     F: FnOnce() -> Result<T>,
 {
@@ -382,10 +430,38 @@ where
 
     let mut stderr = std::io::stderr();
     let symbol = if result.is_ok() { "✓" } else { "✗" };
-    let _ = writeln!(stderr, "\r\x1b[2K{}\x1b[90m {}\x1b[0m", symbol, label);
+    if plain {
+        let _ = writeln!(stderr, "{} {}", symbol, label);
+    } else if result.is_ok() {
+        let _ = writeln!(
+            stderr,
+            "\r\x1b[2K\x1b[32m{}\x1b[0m\x1b[90m {}\x1b[0m",
+            symbol, label
+        );
+    } else {
+        let _ = writeln!(
+            stderr,
+            "\r\x1b[2K\x1b[31m{}\x1b[0m\x1b[90m {}\x1b[0m",
+            symbol, label
+        );
+    }
     let _ = stderr.flush();
 
     result
+}
+
+fn status_chip(status: &str, plain: bool) -> String {
+    if plain {
+        return format!("[{}]", status.to_uppercase());
+    }
+    match status {
+        "installed" | "updated" | "removed" => format!("\x1b[30;42m {} \x1b[0m", status),
+        "unchanged" => format!("\x1b[30;47m {} \x1b[0m", status),
+        "would_install" | "would_update" | "would_remove" => {
+            format!("\x1b[30;43m {} \x1b[0m", status)
+        }
+        _ => format!("\x1b[30;41m {} \x1b[0m", status),
+    }
 }
 
 fn install_hooks(config_path: &str, timeout: u64, ttl: u64) -> Result<()> {


### PR DESCRIPTION
## Summary\n- add cassette-style ASCII banner with Japanese label\n- improve animated sync UX with clearer success/failure visuals\n- add  mode for CI-safe output\n- add  mode for detailed per-action status output\n\n## Notes\n- keeps JSON mode unchanged for machine consumers\n- passes fmt/clippy/test/build locally