### PR TITLE
feat: add kasetto init command for interactive config scaffolding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+just fmt        # Format code with cargo fmt
+just lint       # Run clippy with warnings-as-errors
+just test       # Run all tests
+just build      # Build release binary
+just check      # Run fmt + lint + test + build
+
+cargo test <test_name>  # Run a single test by name
+```
+
+## Architecture
+
+Kasetto is a Rust CLI tool (~3,600 lines) that syncs AI skill packs across 40+ agent environments (Claude Code, Cursor, Windsurf, Copilot, etc.). The entry point is `src/main.rs`, which sets a global `mimalloc` allocator and delegates to `lib::run()`.
+
+**Data flow**: CLI parsing → `app.rs` router → command handler → `fsops.rs` → SQLite manifest
+
+### Key modules
+
+- **`app.rs`** — Startup router: decides between home TUI (no args, no config), explicit command, or default config sync
+- **`cli.rs`** — `clap`-based argument parsing; all commands/flags defined here
+- **`commands/`** — One file per command: `sync.rs` (main logic), `list.rs`, `doctor.rs`, `self_update.rs`
+- **`fsops.rs`** (~695 lines) — All file system and network operations: config loading (local YAML or HTTPS URL), GitHub repo fetching via tar.gz API, SHA256 directory hashing, SQLite manifest read/write, path resolution
+- **`model.rs`** — Core types: `Config` (YAML config), `Agent` enum (40+ presets with platform paths), `SkillEntry` (tracked skill with hash/timestamp), `State` (in-memory manifest), `Report`/`Summary` (sync results)
+- **`profile.rs`** — Parses `SKILL.md` frontmatter and extracts skill metadata; falls back through: YAML frontmatter → heading → first body line
+- **`home.rs`** (~554 lines) — Interactive TUI when no config exists; vim-style navigation (j/k, gg/G, PgUp/PgDn)
+- **`list.rs`** (~759 lines) — Skill browser TUI with multi-column layout and JSON export mode
+- **`ui.rs`** — Spinner animations and status chips; suppressed in `--quiet`/`--json`/`--plain` modes
+
+### Config format (`skills.config.yaml`)
+
+```yaml
+agent: claude-code        # OR destination: ./path  (agent maps to platform-specific path)
+skills:
+  - source: https://github.com/org/repo
+    branch: main          # optional, falls back main→master
+    skills: "*"           # or list of { name, path } objects
+  - source: ~/local/path
+    skills:
+      - skill-name
+```
+
+### Sync logic
+
+1. Load YAML config (local file or HTTPS)
+2. For each source: fetch GitHub repo (tar.gz) or read local directory
+3. Discover skills via `SKILL.md` presence
+4. SHA256-hash each skill directory; compare against SQLite manifest
+5. Install/update changed skills, remove deleted ones
+6. Persist new state to SQLite
+
+## Commit convention
+
+Follows [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `ci:`, `build:`, `perf:`, `style:`, `design:`, `revert:`
+
+Example: `feat(sync): add support for private GitHub repos`

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,6 +23,7 @@ pub fn run() -> Result<()> {
             Commands::List { json } => crate::commands::list::run(json),
             Commands::Doctor { json } => crate::commands::doctor::run(json),
             Commands::SelfUpdate { json } => crate::commands::self_update::run(json),
+            Commands::Init { force } => crate::commands::init::run(force),
             Commands::Completions { shell } => {
                 let mut cmd = Cli::command();
                 let bin = program_name;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -107,6 +107,16 @@ pub enum Commands {
         json: bool,
     },
     #[command(
+        about = "Create a new skills.config.yaml interactively",
+        long_about = "Launch an interactive wizard to scaffold skills.config.yaml.\n\nGuides you through choosing an agent and adding skill sources.",
+        after_help = "\x1b[1;35mExamples:\x1b[0m\n  \x1b[90mkasetto init\x1b[0m\n  \x1b[90mkasetto init --force\x1b[0m"
+    )]
+    Init {
+        #[arg(long, short = 'f')]
+        #[arg(help = "overwrite existing config")]
+        force: bool,
+    },
+    #[command(
         about = "Generate shell completions",
         long_about = "Generate shell completion scripts for kasetto.\n\nThe output is written to stdout so it can be sourced directly or redirected to a file.",
         after_help = "\x1b[1;35mExamples:\x1b[0m\n  \x1b[90mkasetto completions bash\x1b[0m\n  \x1b[90mkasetto completions zsh\x1b[0m\n  \x1b[90mkasetto completions fish\x1b[0m\n  \x1b[90mkasetto completions powershell\x1b[0m"

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,469 @@
+use std::io::{stdin, stdout, IsTerminal, Stdout, Write};
+use std::path::Path;
+
+use crossterm::cursor::{Hide, MoveTo, Show};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::execute;
+use crossterm::style::{Attribute, Color, Print, ResetColor, SetAttribute, SetForegroundColor};
+use crossterm::terminal::{
+    self, disable_raw_mode, enable_raw_mode, Clear, ClearType, EnterAlternateScreen,
+    LeaveAlternateScreen,
+};
+
+use crate::error::{err, Result};
+
+const CONFIG_FILE: &str = "skills.config.yaml";
+
+/// All supported agents — popular ones first, then alphabetical.
+const AGENTS: &[&str] = &[
+    "claude-code",
+    "cursor",
+    "windsurf",
+    "codex",
+    "amp",
+    "cline",
+    "github-copilot",
+    "opencode",
+    "openhands",
+    "goose",
+    "gemini-cli",
+    "adal",
+    "antigravity",
+    "augment",
+    "codebuddy",
+    "command-code",
+    "continue",
+    "cortex",
+    "crush",
+    "deepagents",
+    "droid",
+    "iflow-cli",
+    "junie",
+    "kilo",
+    "kimi-cli",
+    "kiro-cli",
+    "kode",
+    "mcpjam",
+    "mistral-vibe",
+    "mux",
+    "neovate",
+    "openclaw",
+    "pi",
+    "pochi",
+    "qoder",
+    "qwen-code",
+    "replit",
+    "roo",
+    "trae",
+    "trae-cn",
+    "universal",
+    "warp",
+    "zencoder",
+];
+
+pub fn run(force: bool) -> Result<()> {
+    if !stdin().is_terminal() {
+        return Err(err("kasetto init requires an interactive terminal"));
+    }
+    if Path::new(CONFIG_FILE).exists() && !force {
+        return Err(err(format!(
+            "{CONFIG_FILE} already exists. Use --force to overwrite."
+        )));
+    }
+
+    println!();
+
+    let agent = match select_agent()? {
+        Some(a) => a,
+        None => {
+            println!("  Cancelled.");
+            return Ok(());
+        }
+    };
+
+    println!();
+
+    let mut sources: Vec<(String, String)> = Vec::new();
+
+    loop {
+        println!("    A GitHub repo or local directory containing skill subdirectories.");
+        println!("    Leave blank to skip and add sources manually later.");
+        println!();
+        let url = match prompt_text("  Source:", "")? {
+            None => {
+                println!("  Cancelled.");
+                return Ok(());
+            }
+            Some(s) if s.trim().is_empty() => break,
+            Some(s) => s.trim().to_string(),
+        };
+
+        let skills = match prompt_text("  Skills (* for all, or comma-separated names):", "*")? {
+            None => {
+                println!("  Cancelled.");
+                return Ok(());
+            }
+            Some(s) if s.trim().is_empty() => "*".to_string(),
+            Some(s) => s.trim().to_string(),
+        };
+
+        sources.push((url, skills));
+        println!();
+
+        match prompt_yn("  Add another source?")? {
+            None => {
+                println!("  Cancelled.");
+                return Ok(());
+            }
+            Some(true) => {
+                println!();
+                continue;
+            }
+            Some(false) => break,
+        }
+    }
+
+    write_config(&agent, &sources)?;
+
+    let mut out = stdout();
+    println!();
+    execute!(
+        out,
+        Print("  "),
+        SetForegroundColor(Color::Green),
+        SetAttribute(Attribute::Bold),
+        Print("✓"),
+        SetAttribute(Attribute::Reset),
+        ResetColor,
+        Print(format!(" Created {CONFIG_FILE}\n")),
+    )?;
+    if sources.is_empty() {
+        println!("    Edit {CONFIG_FILE} to add a source, then run kasetto sync.");
+    } else {
+        println!("    Run kasetto sync to install your skills.");
+    }
+    println!();
+
+    Ok(())
+}
+
+fn select_agent() -> Result<Option<String>> {
+    let mut stdout = stdout();
+    enable_raw_mode()?;
+    execute!(stdout, EnterAlternateScreen, Hide)?;
+
+    let result = run_agent_selector(&mut stdout);
+
+    let _ = disable_raw_mode();
+    let _ = execute!(stdout, Show, LeaveAlternateScreen);
+
+    result
+}
+
+fn run_agent_selector(stdout: &mut Stdout) -> Result<Option<String>> {
+    let mut selected = 0usize;
+    let mut scroll = 0usize;
+
+    loop {
+        let (_, height) = terminal::size()?;
+        let visible = (height as usize).saturating_sub(7);
+
+        if selected < scroll {
+            scroll = selected;
+        } else if visible > 0 && selected >= scroll + visible {
+            scroll = selected + 1 - visible;
+        }
+
+        draw_agent_selector(stdout, selected, scroll, visible)?;
+
+        match event::read()? {
+            Event::Key(key) if key.kind != KeyEventKind::Release => match key.code {
+                KeyCode::Up | KeyCode::Char('k') => {
+                    selected = selected.saturating_sub(1);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    if selected + 1 < AGENTS.len() {
+                        selected += 1;
+                    }
+                }
+                KeyCode::Char('g') => {
+                    selected = 0;
+                    scroll = 0;
+                }
+                KeyCode::Char('G') => {
+                    selected = AGENTS.len() - 1;
+                }
+                KeyCode::PageUp => {
+                    selected = selected.saturating_sub(visible.max(1));
+                }
+                KeyCode::PageDown => {
+                    selected = (selected + visible.max(1)).min(AGENTS.len() - 1);
+                }
+                KeyCode::Enter => {
+                    return Ok(Some(AGENTS[selected].to_string()));
+                }
+                KeyCode::Esc | KeyCode::Char('q') => {
+                    return Ok(None);
+                }
+                KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    return Ok(None);
+                }
+                _ => {}
+            },
+            Event::Resize(_, _) => {}
+            _ => {}
+        }
+    }
+}
+
+fn draw_agent_selector(
+    stdout: &mut Stdout,
+    selected: usize,
+    scroll: usize,
+    visible: usize,
+) -> Result<()> {
+    let (width, height) = terminal::size()?;
+    let width = width as usize;
+    let height = height as usize;
+
+    execute!(stdout, MoveTo(0, 0), Clear(ClearType::All))?;
+
+    execute!(
+        stdout,
+        MoveTo(0, 0),
+        SetForegroundColor(Color::Magenta),
+        SetAttribute(Attribute::Bold),
+        Print("kasetto init"),
+        SetAttribute(Attribute::Reset),
+        ResetColor,
+    )?;
+    execute!(
+        stdout,
+        MoveTo(0, 1),
+        SetForegroundColor(Color::DarkGrey),
+        Print("Choose your agent"),
+        ResetColor,
+    )?;
+    execute!(
+        stdout,
+        MoveTo(0, 2),
+        SetForegroundColor(Color::DarkGrey),
+        Print("─".repeat(width.min(50))),
+        ResetColor,
+    )?;
+
+    for i in 0..visible {
+        let idx = scroll + i;
+        if idx >= AGENTS.len() {
+            break;
+        }
+        execute!(stdout, MoveTo(0, (3 + i) as u16))?;
+        if idx == selected {
+            execute!(
+                stdout,
+                SetForegroundColor(Color::Cyan),
+                SetAttribute(Attribute::Bold),
+                Print(format!("  › {}", AGENTS[idx])),
+                SetAttribute(Attribute::Reset),
+                ResetColor,
+            )?;
+        } else {
+            execute!(
+                stdout,
+                SetForegroundColor(Color::DarkGrey),
+                Print("    "),
+                ResetColor,
+                Print(AGENTS[idx]),
+            )?;
+        }
+    }
+
+    if scroll > 0 {
+        execute!(
+            stdout,
+            MoveTo(0, 3),
+            SetForegroundColor(Color::DarkGrey),
+            Print("  ↑ more above"),
+            ResetColor,
+        )?;
+    }
+    if scroll + visible < AGENTS.len() {
+        execute!(
+            stdout,
+            MoveTo(0, (3 + visible.saturating_sub(1)) as u16),
+            SetForegroundColor(Color::DarkGrey),
+            Print("  ↓ more below"),
+            ResetColor,
+        )?;
+    }
+
+    execute!(
+        stdout,
+        MoveTo(0, height.saturating_sub(3) as u16),
+        SetForegroundColor(Color::DarkGrey),
+        Print("─".repeat(width.min(50))),
+        ResetColor,
+    )?;
+    execute!(
+        stdout,
+        MoveTo(0, height.saturating_sub(2) as u16),
+        SetForegroundColor(Color::DarkGrey),
+        Print(format!("{}/{} agents", selected + 1, AGENTS.len())),
+        ResetColor,
+    )?;
+    execute!(
+        stdout,
+        MoveTo(0, height.saturating_sub(1) as u16),
+        SetForegroundColor(Color::DarkGrey),
+        Print("j/k  ↑/↓  Enter to select  gg/G to jump  Esc to cancel"),
+        ResetColor,
+    )?;
+
+    stdout.flush()?;
+    Ok(())
+}
+
+fn prompt_text(label: &str, default: &str) -> Result<Option<String>> {
+    let mut stdout = stdout();
+    let mut input = String::new();
+
+    enable_raw_mode()?;
+    execute!(stdout, Show)?;
+
+    loop {
+        execute!(
+            stdout,
+            Print("\r"),
+            Clear(ClearType::CurrentLine),
+            SetForegroundColor(Color::Cyan),
+            SetAttribute(Attribute::Bold),
+            Print(label),
+            SetAttribute(Attribute::Reset),
+            ResetColor,
+            Print(" "),
+        )?;
+
+        if input.is_empty() && !default.is_empty() {
+            execute!(
+                stdout,
+                SetForegroundColor(Color::DarkGrey),
+                Print(default),
+                ResetColor,
+            )?;
+        } else {
+            execute!(stdout, Print(&input))?;
+        }
+        stdout.flush()?;
+
+        match event::read()? {
+            Event::Key(key) if key.kind != KeyEventKind::Release => match key.code {
+                KeyCode::Enter => {
+                    execute!(stdout, Print("\r\n"))?;
+                    let _ = disable_raw_mode();
+                    return Ok(Some(input));
+                }
+                KeyCode::Esc => {
+                    execute!(stdout, Print("\r\n"))?;
+                    let _ = disable_raw_mode();
+                    return Ok(None);
+                }
+                KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    execute!(stdout, Print("\r\n"))?;
+                    let _ = disable_raw_mode();
+                    return Ok(None);
+                }
+                KeyCode::Backspace => {
+                    input.pop();
+                }
+                KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    input.clear();
+                }
+                KeyCode::Char(ch) => {
+                    input.push(ch);
+                }
+                _ => {}
+            },
+            Event::Paste(text) => {
+                input.push_str(&text);
+            }
+            Event::Resize(_, _) => {}
+            _ => {}
+        }
+    }
+}
+
+fn prompt_yn(label: &str) -> Result<Option<bool>> {
+    let mut stdout = stdout();
+    enable_raw_mode()?;
+    execute!(stdout, Show)?;
+
+    execute!(
+        stdout,
+        SetForegroundColor(Color::Cyan),
+        SetAttribute(Attribute::Bold),
+        Print(label),
+        SetAttribute(Attribute::Reset),
+        ResetColor,
+        Print(" [y/N] "),
+    )?;
+    stdout.flush()?;
+
+    let result = loop {
+        match event::read()? {
+            Event::Key(key) if key.kind != KeyEventKind::Release => match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    execute!(stdout, Print("y\r\n"))?;
+                    break Ok(Some(true));
+                }
+                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Enter => {
+                    execute!(stdout, Print("N\r\n"))?;
+                    break Ok(Some(false));
+                }
+                KeyCode::Esc => {
+                    execute!(stdout, Print("\r\n"))?;
+                    break Ok(None);
+                }
+                KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    execute!(stdout, Print("\r\n"))?;
+                    break Ok(None);
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    };
+
+    let _ = disable_raw_mode();
+    result
+}
+
+fn write_config(agent: &str, sources: &[(String, String)]) -> Result<()> {
+    let mut content = String::new();
+    content.push_str(&format!("agent: {agent}\n\n"));
+    content.push_str("skills:\n");
+
+    if sources.is_empty() {
+        content.push_str("  # Add a source to get started, for example:\n");
+        content.push_str("  # - source: https://github.com/org/my-skills-repo\n");
+        content.push_str("  #   skills: \"*\"\n");
+    }
+
+    for (source, skills) in sources {
+        content.push_str(&format!("  - source: {source}\n"));
+        if skills == "*" {
+            content.push_str("    skills: \"*\"\n");
+        } else {
+            content.push_str("    skills:\n");
+            for name in skills.split(',') {
+                let name = name.trim();
+                if !name.is_empty() {
+                    content.push_str(&format!("      - {name}\n"));
+                }
+            }
+        }
+    }
+
+    std::fs::write(CONFIG_FILE, content)
+        .map_err(|e| err(format!("failed to write {CONFIG_FILE}: {e}")))?;
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod doctor;
+pub mod init;
 pub mod list;
 pub mod self_update;
 pub mod sync;


### PR DESCRIPTION
## Summary

- Adds \`kasetto init\` / \`kst init\` — an interactive TUI wizard that scaffolds \`skills.config.yaml\` for new users
- Full-screen scrollable agent selector (all 43 agents, popular ones first; j/k, gg/G, PageUp/Down navigation)
- Sequential inline prompts for source URL/path and skill selection (\`*\` or comma-separated names), with multi-source support
- Source step is skippable — users without a skills repo yet get a commented placeholder in the generated YAML
- Handles Ctrl-C, Esc, and Ctrl-U across all interactive prompts; guards against non-TTY and existing config (\`--force\` to overwrite)

## Test plan

- [ ] \`kasetto init\` — walk through full wizard, verify \`skills.config.yaml\` written correctly
- [ ] \`kasetto init --force\` — verify overwrites existing config
- [ ] Skip source step (blank Enter) — verify commented placeholder written, success message says to edit file
- [ ] Ctrl-C at each prompt stage — verify terminal state restored cleanly
- [ ] \`echo "" | kasetto init\` — verify non-TTY error
- [ ] \`kst init\` — verify alias works identically
- [ ] \`cargo test\` passes, \`cargo clippy -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.ai/code)