### PR TITLE
feat(config): add global default config fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Kasetto is a single-binary CLI tool that syncs AI agent skills from GitHub repos
 CLI args → resolve_command() → StartupMode
   ├─ Explicit subcommand → run that command
   ├─ Root sync flags (--config, --dry-run, etc.) → Sync
-  ├─ kasetto.yaml exists in cwd → Sync (default config)
+  ├─ default config exists (`./kasetto.yaml` or `~/.config/kasetto/config.yaml`) → Sync
   └─ Nothing → Home screen (interactive TUI menu)
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ kst sync [--config <path-or-url>] [--dry-run] [--quiet] [--json] [--plain] [--ve
 
 | Flag        | What it does                                                 |
 | ----------- | ------------------------------------------------------------ |
-| `--config`  | Path or HTTPS URL to a YAML config (default: `kasetto.yaml`) |
+| `--config`  | Path or HTTPS URL to a YAML config (default order: `./kasetto.yaml`, then `$XDG_CONFIG_HOME/kasetto/config.yaml`) |
 | `--dry-run` | Preview what would change without writing anything           |
 | `--quiet`   | Suppress non-error output                                    |
 | `--json`    | Print the sync report as JSON                                |
@@ -201,7 +201,12 @@ Supported shells: `bash`, `zsh`, `fish`, `powershell`.
 
 ## Configuration
 
-Kasetto looks for `kasetto.yaml` in the current directory by default. Point it at a specific file or URL with `--config`, or run `kst init` to generate a starter.
+When `--config` is omitted, Kasetto looks for config in this order:
+
+1. `./kasetto.yaml`
+2. `$XDG_CONFIG_HOME/kasetto/config.yaml` (or `~/.config/kasetto/config.yaml`)
+
+Point it at a specific file or URL with `--config`, or run `kst init` to generate a starter `kasetto.yaml` in the current directory.
 
 ```yaml
 # Choose an agent preset (single or multiple)...

--- a/README.md
+++ b/README.md
@@ -107,15 +107,16 @@ kst doctor    # version, paths, last sync status
 
 ### `kst init`
 
-Generates a starter `kasetto.yaml` in the current directory.
+Generates a starter config file (`./kasetto.yaml` by default, or global config with `--global`).
 
 ```bash
-kst init [--force]
+kst init [--global] [--force]
 ```
 
-| Flag      | What it does                                        |
-| --------- | --------------------------------------------------- |
-| `--force` | Overwrite an existing `kasetto.yaml` without asking |
+| Flag       | What it does                                                                           |
+| ---------- | -------------------------------------------------------------------------------------- |
+| `--global` | Write `$XDG_CONFIG_HOME/kasetto/config.yaml` (or `~/.config/kasetto/config.yaml`)    |
+| `--force`  | Overwrite an existing config file without asking                                       |
 
 ### `kst sync`
 
@@ -206,7 +207,7 @@ When `--config` is omitted, Kasetto looks for config in this order:
 1. `./kasetto.yaml`
 2. `$XDG_CONFIG_HOME/kasetto/config.yaml` (or `~/.config/kasetto/config.yaml`)
 
-Point it at a specific file or URL with `--config`, or run `kst init` to generate a starter `kasetto.yaml` in the current directory.
+Point it at a specific file or URL with `--config`, or run `kst init` for local `./kasetto.yaml` (`kst init --global` writes the global config file).
 
 ```yaml
 # Choose an agent preset (single or multiple)...

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,7 +2,7 @@
 
 ## `kst init`
 
-Generates a starter `kasetto.yaml` in the current directory — a good jumping-off point before you edit by hand.
+Generates a starter config file — local `./kasetto.yaml` by default, or global config with `--global`.
 
 ```bash
 kst init [OPTIONS]
@@ -10,9 +10,10 @@ kst init [OPTIONS]
 
 ### Options
 
-| Flag      | Description                                            |
-| --------- | ------------------------------------------------------ |
-| `--force` | Overwrite an existing `kasetto.yaml` without prompting |
+| Flag       | Description                                                                       |
+| ---------- | --------------------------------------------------------------------------------- |
+| `--global` | Write `$XDG_CONFIG_HOME/kasetto/config.yaml` (or `~/.config/kasetto/config.yaml`) |
+| `--force`  | Overwrite an existing config file without prompting                               |
 
 ## `kst sync`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -26,7 +26,7 @@ kst sync [OPTIONS]
 
 | Flag                     | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `--config <path-or-url>` | Path or HTTPS URL to a YAML config (default: `kasetto.yaml`) |
+| `--config <path-or-url>` | Path or HTTPS URL to a YAML config (default order: `./kasetto.yaml`, then `$XDG_CONFIG_HOME/kasetto/config.yaml`) |
 | `--dry-run`              | Preview what would change without writing anything           |
 | `--quiet`                | Suppress non-error output                                    |
 | `--json`                 | Print the sync report as JSON                                |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ When `--config` is omitted, Kasetto looks for config in this order:
 1. `./kasetto.yaml`
 2. `$XDG_CONFIG_HOME/kasetto/config.yaml` (or `~/.config/kasetto/config.yaml`)
 
-Point it at a specific file or URL with `--config`, or run `kst init` to generate a starter `kasetto.yaml` in the current directory.
+Point it at a specific file or URL with `--config`, or run `kst init` for local `./kasetto.yaml` (`kst init --global` writes the global config file).
 
 ## Example
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,11 @@
 # Configuration
 
-Kasetto looks for `kasetto.yaml` in the current directory by default. Point it at a specific file or URL with `--config`, or run `kst init` to generate a starter.
+When `--config` is omitted, Kasetto looks for config in this order:
+
+1. `./kasetto.yaml`
+2. `$XDG_CONFIG_HOME/kasetto/config.yaml` (or `~/.config/kasetto/config.yaml`)
+
+Point it at a specific file or URL with `--config`, or run `kst init` to generate a starter `kasetto.yaml` in the current directory.
 
 ## Example
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,8 @@ Run `kst init` to generate a starter config:
 kst init
 ```
 
+Use `kst init --global` to create `$XDG_CONFIG_HOME/kasetto/config.yaml` (or `~/.config/kasetto/config.yaml`).
+
 Or create a `kasetto.yaml` by hand:
 
 ```yaml

--- a/docs/how-sync-works.md
+++ b/docs/how-sync-works.md
@@ -5,7 +5,7 @@ A look at what `kst sync` actually does — how skills are installed, how MCP co
 ## Sync Flow
 
 ```
-1. Load config (kasetto.yaml or --config URL)
+1. Load config (`./kasetto.yaml`, then `$XDG_CONFIG_HOME/kasetto/config.yaml`, or `--config` path/URL)
 2. Load lock file (kasetto.lock)
 3. Sync skills
    a. For each skill source: materialize (download if remote)

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ pub fn run() -> Result<()> {
     let default_config = default_config_path();
     match resolve_command(cli, Path::new(&default_config).exists()) {
         StartupMode::Command(command) => match command {
-            Commands::Init { force } => crate::commands::init::run(force),
+            Commands::Init { force, global } => crate::commands::init::run(force, global),
             Commands::Sync { sync } => {
                 let config = sync.config.unwrap_or_else(|| default_config.clone());
                 crate::commands::sync::run(&crate::commands::sync::SyncOptions {

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,19 +2,18 @@ use clap::Parser;
 use std::path::Path;
 
 use crate::cli::{Cli, Commands, SelfAction, SyncArgs};
+use crate::default_config_path;
 use crate::error::Result;
-use crate::DEFAULT_CONFIG_FILENAME;
 
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
     let program_name = current_program_name();
-    match resolve_command(cli, Path::new(DEFAULT_CONFIG_FILENAME).exists()) {
+    let default_config = default_config_path();
+    match resolve_command(cli, Path::new(&default_config).exists()) {
         StartupMode::Command(command) => match command {
             Commands::Init { force } => crate::commands::init::run(force),
             Commands::Sync { sync } => {
-                let config = sync
-                    .config
-                    .unwrap_or_else(|| DEFAULT_CONFIG_FILENAME.into());
+                let config = sync.config.unwrap_or_else(|| default_config.clone());
                 crate::commands::sync::run(&crate::commands::sync::SyncOptions {
                     config_path: &config,
                     dry_run: sync.dry_run,
@@ -64,7 +63,7 @@ pub fn run() -> Result<()> {
                 crate::commands::completions::run(shell, &program_name)
             }
         },
-        StartupMode::Home => crate::home::run(&program_name, DEFAULT_CONFIG_FILENAME),
+        StartupMode::Home => crate::home::run(&program_name, &default_config),
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,7 +68,7 @@ pub(crate) struct SyncArgs {
     #[arg(long)]
     #[arg(
         help = "config path or HTTP(S) URL",
-        long_help = "Configuration location. Supports:\n- local file path (default: kasetto.yaml)\n- HTTP(S) URL to a YAML config file"
+        long_help = "Configuration location. Supports:\n- local file path\n- HTTP(S) URL to a YAML config file\n\nWhen omitted, kasetto checks defaults in this order:\n1) ./kasetto.yaml\n2) $XDG_CONFIG_HOME/kasetto/config.yaml (or ~/.config/kasetto/config.yaml)"
     )]
     pub config: Option<String>,
     #[arg(long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,14 +106,21 @@ impl SyncArgs {
 #[derive(Subcommand)]
 pub(crate) enum Commands {
     #[command(
-        about = "Create a starter kasetto.yaml in the current directory",
-        long_about = "Writes a commented template you can edit before running sync.\n\nIf kasetto.yaml already exists, you are prompted to overwrite (TTY) unless `--force` is set.",
-        after_help = crate::cli_examples!("kasetto init", "kasetto init --force",)
+        about = "Create a starter config file",
+        long_about = "Writes a commented template you can edit before running sync.\n\nBy default, writes ./kasetto.yaml. With --global, writes $XDG_CONFIG_HOME/kasetto/config.yaml (or ~/.config/kasetto/config.yaml).\n\nIf the target file already exists, you are prompted to overwrite (TTY) unless `--force` is set.",
+        after_help = crate::cli_examples!(
+            "kasetto init",
+            "kasetto init --global",
+            "kasetto init --force",
+        )
     )]
     Init {
         #[arg(short, long)]
-        #[arg(help = "overwrite an existing kasetto.yaml without prompting")]
+        #[arg(help = "overwrite an existing config file without prompting")]
         force: bool,
+        #[arg(long)]
+        #[arg(help = "write global config to $XDG_CONFIG_HOME/kasetto/config.yaml")]
+        global: bool,
     },
     #[command(
         about = "Sync skills from configured sources",

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,12 +1,13 @@
 use std::fs;
 use std::io::{self, IsTerminal, Write};
-use std::path::Path;
+use std::path::PathBuf;
 
 use crate::banner::print_banner;
 use crate::colors::{ACCENT, RESET, SECONDARY, SUCCESS, WARNING};
 use crate::error::{err, Result};
+use crate::fsops::dirs_kasetto_config;
 use crate::ui::{SYM_FAIL, SYM_OK};
-use crate::DEFAULT_CONFIG_FILENAME;
+use crate::{DEFAULT_CONFIG_FILENAME, DEFAULT_GLOBAL_CONFIG_FILENAME};
 
 const TEMPLATE: &str = r#"# Kasetto - https://github.com/pivoshenko/kasetto
 
@@ -37,10 +38,10 @@ const TEMPLATE: &str = r#"# Kasetto - https://github.com/pivoshenko/kasetto
 #     path: .mcp.json         # explicit path to MCP JSON within the repo
 "#;
 
-pub(crate) fn run(force: bool) -> Result<()> {
+pub(crate) fn run(force: bool, global: bool) -> Result<()> {
     print_banner();
     println!();
-    let path = Path::new(DEFAULT_CONFIG_FILENAME);
+    let path = init_config_path(global)?;
 
     if path.exists() && !force {
         println!(
@@ -64,7 +65,10 @@ pub(crate) fn run(force: bool) -> Result<()> {
         }
     }
 
-    fs::write(path, TEMPLATE)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&path, TEMPLATE)?;
 
     println!(
         "{SUCCESS}{SYM_OK}{RESET} Created {ACCENT}{}{RESET}",
@@ -80,4 +84,28 @@ pub(crate) fn run(force: bool) -> Result<()> {
     println!("  3. Run {ACCENT}kasetto sync{RESET} to install skills");
 
     Ok(())
+}
+
+fn init_config_path(global: bool) -> Result<PathBuf> {
+    if global {
+        return Ok(dirs_kasetto_config()?.join(DEFAULT_GLOBAL_CONFIG_FILENAME));
+    }
+    Ok(PathBuf::from(DEFAULT_CONFIG_FILENAME))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::init_config_path;
+
+    #[test]
+    fn init_path_defaults_to_local_config() {
+        let path = init_config_path(false).expect("local path");
+        assert_eq!(path, std::path::PathBuf::from("kasetto.yaml"));
+    }
+
+    #[test]
+    fn init_path_global_uses_kasetto_config_dir() {
+        let path = init_config_path(true).expect("global path");
+        assert!(path.ends_with("kasetto/config.yaml"));
+    }
 }

--- a/src/home/mod.rs
+++ b/src/home/mod.rs
@@ -39,7 +39,7 @@ pub(crate) fn run(program_name: &str, default_config: &str) -> Result<()> {
                 show_banner: true,
             })
         }
-        HomeAction::Init => crate::commands::init::run(false),
+        HomeAction::Init => crate::commands::init::run(false, false),
         HomeAction::List => crate::commands::list::run(false, false, false, None),
         HomeAction::Doctor => crate::commands::doctor::run(false, false, false, None, program_name),
         HomeAction::SelfUpdate => crate::commands::self_update::run(false),
@@ -93,7 +93,7 @@ struct HomeItem {
 const HOME_ITEMS: [HomeItem; 7] = [
     HomeItem {
         title: "init",
-        command: "kasetto init [--force]",
+        command: "kasetto init [--global] [--force]",
         action: HomeItemAction::Init,
     },
     HomeItem {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,27 @@
 /// Default config file in the current directory when `--config` is omitted.
 pub(crate) const DEFAULT_CONFIG_FILENAME: &str = "kasetto.yaml";
+/// Default config file under the Kasetto XDG config directory.
+pub(crate) const DEFAULT_GLOBAL_CONFIG_FILENAME: &str = "config.yaml";
+
+/// Resolve the default config path used when `--config` is omitted.
+///
+/// Priority: local `kasetto.yaml` in CWD, then `$XDG_CONFIG_HOME/kasetto/config.yaml`
+/// (or `$HOME/.config/kasetto/config.yaml`), then local `kasetto.yaml` fallback.
+pub(crate) fn default_config_path() -> String {
+    if std::path::Path::new(DEFAULT_CONFIG_FILENAME).exists() {
+        return DEFAULT_CONFIG_FILENAME.to_string();
+    }
+
+    if let Ok(global) =
+        crate::fsops::dirs_kasetto_config().map(|dir| dir.join(DEFAULT_GLOBAL_CONFIG_FILENAME))
+    {
+        if global.exists() {
+            return global.to_string_lossy().to_string();
+        }
+    }
+
+    DEFAULT_CONFIG_FILENAME.to_string()
+}
 
 mod app;
 mod banner;

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -41,7 +41,8 @@ impl Config {
 /// Resolve the effective scope: CLI override > config YAML `scope:` field > Global default.
 ///
 /// When a `Config` is already loaded, pass it directly. Otherwise the function
-/// reads `kasetto.yaml` from the current directory as a fallback.
+/// reads the default config path (local `kasetto.yaml`, then global XDG config)
+/// as a fallback.
 pub(crate) fn resolve_scope(cli_override: Option<Scope>, cfg: Option<&Config>) -> Scope {
     if let Some(s) = cli_override {
         return s;
@@ -49,12 +50,23 @@ pub(crate) fn resolve_scope(cli_override: Option<Scope>, cfg: Option<&Config>) -
     if let Some(cfg) = cfg {
         return cfg.resolved_scope();
     }
-    if let Ok(text) = std::fs::read_to_string(crate::DEFAULT_CONFIG_FILENAME) {
+    if let Ok(text) = std::fs::read_to_string(crate::default_config_path()) {
         if let Ok(cfg) = serde_yaml::from_str::<Config>(&text) {
             return cfg.resolved_scope();
         }
     }
     Scope::Global
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_scope, Scope};
+
+    #[test]
+    fn resolve_scope_prefers_cli_override() {
+        assert_eq!(resolve_scope(Some(Scope::Project), None), Scope::Project);
+        assert_eq!(resolve_scope(Some(Scope::Global), None), Scope::Global);
+    }
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
# Pull Request Checklist

**Resolves: N/A**

## Summary

- Add default config resolution that checks `./kasetto.yaml` first, then falls back to `$XDG_CONFIG_HOME/kasetto/config.yaml` (or `~/.config/kasetto/config.yaml`).
- Use the resolved default config path for startup routing, implicit `sync` config selection, and scope fallback resolution.
- Update CLI/docs to reflect the new default-config search order.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors

## Screenshots (if applicable)

N/A

## Additional Notes

- Verification run: `cargo test` (86 passed).