### PR TITLE
security: add self-update checksum verification and MCP install confirmation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -21,6 +21,7 @@ pub fn run() -> Result<()> {
                     as_json: sync.json,
                     plain: sync.plain,
                     verbose: sync.verbose,
+                    no_confirm: sync.no_confirm,
                     scope_override: sync.scope.scope_override(),
                     show_banner: true,
                 })
@@ -78,3 +79,4 @@ fn current_program_name() -> String {
         .filter(|name| !name.is_empty())
         .unwrap_or_else(|| "kasetto".to_string())
 }
+

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,9 +82,13 @@ pub(crate) struct SyncArgs {
     #[arg(long)]
     #[arg(help = "print per-skill action list")]
     pub verbose: bool,
+    #[arg(long)]
+    #[arg(help = "skip confirmation prompt when registering new MCP servers")]
+    pub no_confirm: bool,
     #[command(flatten)]
     pub scope: ScopeArgs,
 }
+
 
 #[derive(Subcommand)]
 pub(crate) enum Commands {

--- a/src/commands/self_update.rs
+++ b/src/commands/self_update.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::io::IsTerminal;
 
+use sha2::{Digest, Sha256};
+
 use crate::banner::print_banner_or_plain;
 use crate::colors::{ACCENT, RESET, SECONDARY, SUCCESS};
 use crate::error::{err, Result};
@@ -143,13 +145,56 @@ fn is_newer(current: &str, latest: &str) -> bool {
     parse(latest) > parse(current)
 }
 
+fn checksums_url(tarball_url: &str) -> String {
+    match tarball_url.rfind('/') {
+        Some(pos) => format!("{}/checksums.txt", &tarball_url[..pos]),
+        None => "checksums.txt".to_string(),
+    }
+}
+
+fn verify_checksum(bytes: &[u8], artifact: &str, checksums_text: &str) -> Result<()> {
+    let actual = format!("{:x}", Sha256::digest(bytes));
+    for line in checksums_text.lines() {
+        // Format: "<hash>  <filename>" (sha256sum output style)
+        let mut parts = line.splitn(2, ' ');
+        let expected = parts.next().unwrap_or("").trim();
+        let name = parts.next().unwrap_or("").trim();
+        if name == artifact {
+            if actual != expected {
+                return Err(err(format!(
+                    "checksum mismatch for {artifact}: expected {expected}, got {actual}"
+                )));
+            }
+            return Ok(());
+        }
+    }
+    // No entry found for this artifact — warn but continue, consistent with install.sh
+    eprintln!("warning: no checksum entry found for {artifact} in checksums.txt");
+    Ok(())
+}
+
 fn self_replace(url: &str, exe_path: &std::path::Path) -> Result<()> {
-    let body = http_client()?
+    let artifact = url.rsplit('/').next().unwrap_or(url).to_string();
+    let checksums_url = checksums_url(url);
+    let client = http_client()?;
+
+    let checksums_text = client
+        .get(&checksums_url)
+        .send()
+        .map_err(|e| err(format!("failed to download checksums.txt: {e}")))?
+        .error_for_status()
+        .map_err(|e| err(format!("checksums.txt download error: {e}")))?
+        .text()
+        .map_err(|e| err(format!("failed to read checksums.txt: {e}")))?;
+
+    let body = client
         .get(url)
         .send()?
         .error_for_status()
         .map_err(|e| err(format!("failed to download update: {e}")))?
         .bytes()?;
+
+    verify_checksum(&body, &artifact, &checksums_text)?;
 
     let gz = flate2::read::GzDecoder::new(body.as_ref());
     let mut archive = tar::Archive::new(gz);
@@ -238,5 +283,37 @@ mod tests {
     fn current_target_returns_nonempty_string() {
         let target = current_target();
         assert!(!target.is_empty());
+    }
+
+    #[test]
+    fn checksums_url_replaces_filename() {
+        let url = "https://github.com/pivoshenko/kasetto/releases/download/v1.0.0/kasetto-x86_64-apple-darwin.tar.gz";
+        assert_eq!(
+            checksums_url(url),
+            "https://github.com/pivoshenko/kasetto/releases/download/v1.0.0/checksums.txt"
+        );
+    }
+
+    #[test]
+    fn verify_checksum_accepts_correct_hash() {
+        let data = b"hello world";
+        let hash = format!("{:x}", sha2::Sha256::digest(data));
+        let checksums = format!("{hash}  kasetto.tar.gz\n");
+        assert!(verify_checksum(data, "kasetto.tar.gz", &checksums).is_ok());
+    }
+
+    #[test]
+    fn verify_checksum_rejects_wrong_hash() {
+        let data = b"hello world";
+        let checksums = "deadbeef  kasetto.tar.gz\n";
+        assert!(verify_checksum(data, "kasetto.tar.gz", checksums).is_err());
+    }
+
+    #[test]
+    fn verify_checksum_passes_when_artifact_missing() {
+        // No entry for our artifact — warn only, don't fail
+        let data = b"hello world";
+        let checksums = "abc123  other-artifact.tar.gz\n";
+        assert!(verify_checksum(data, "kasetto.tar.gz", checksums).is_ok());
     }
 }

--- a/src/commands/sync/mcps.rs
+++ b/src/commands/sync/mcps.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 use std::fs;
+use std::io::{IsTerminal, Write};
+use std::path::PathBuf;
 
 use crate::error::Result;
 use crate::fsops::{hash_file, now_unix, resolve_mcp_settings_targets};
@@ -10,6 +12,16 @@ use crate::source::{discover_mcps, materialize_source, resolve_mcp_path};
 use crate::ui::with_spinner;
 
 use super::{file_name_str, sync_label, SyncContext};
+
+struct PendingMcp {
+    source: String,
+    mcp_path: PathBuf,
+    file_name: String,
+    hash: String,
+    server_names: Vec<String>,
+    asset_id: String,
+    is_new: bool,
+}
 
 pub(super) fn sync_mcps(
     ctx: &SyncContext,
@@ -22,6 +34,12 @@ pub(super) fn sync_mcps(
     if mcp_settings_list.is_empty() {
         return Ok(());
     }
+
+    // Phase 1: materialise all sources and collect pending operations.
+    // Temp dirs are held in `cleanup_dirs` until after the apply phase,
+    // because `PendingMcp::mcp_path` points into them.
+    let mut pending: Vec<PendingMcp> = Vec::new();
+    let mut cleanup_dirs: Vec<PathBuf> = Vec::new();
 
     for (i, src) in ctx.cfg.mcps.iter().enumerate() {
         let stage = std::env::temp_dir().join(format!("kasetto-mcp-{}-{}", now_unix(), i));
@@ -83,8 +101,10 @@ pub(super) fn sync_mcps(
             }
             continue;
         }
+
         for mcp_path in &mcps {
             let file_name = file_name_str(mcp_path);
+            let file_name_err = file_name.clone();
             let r: std::result::Result<(), crate::error::Error> = (|| {
                 let hash = hash_file(mcp_path)?;
                 let mcp_text = fs::read_to_string(mcp_path)?;
@@ -109,77 +129,134 @@ pub(super) fn sync_mcps(
                     })
                     .unwrap_or(false);
 
-                let label = sync_label("MCP", &file_name, &src.source, ctx.plain);
-                with_spinner(ctx.animate, ctx.plain, &label, || {
-                    if is_unchanged {
-                        summary.unchanged += 1;
-                        actions.push(Action {
-                            source: Some(src.source.clone()),
-                            skill: Some(format!("mcp:{file_name}")),
-                            status: "unchanged".into(),
-                            error: None,
-                        });
-                        return Ok(());
-                    }
-
-                    let status = if existing.is_some() {
-                        if ctx.dry_run {
-                            "would_update"
-                        } else {
-                            "updated"
-                        }
-                    } else if ctx.dry_run {
-                        "would_install"
-                    } else {
-                        "installed"
-                    };
-
-                    if !ctx.dry_run {
-                        for target in &mcp_settings_list {
-                            merge_mcp_config(mcp_path, target)?;
-                        }
-                        let servers_csv = server_names.join(",");
-                        lock.save_tracked_asset(
-                            "mcp",
-                            &asset_id,
-                            &file_name,
-                            &hash,
-                            &src.source,
-                            &servers_csv,
-                        );
-                    }
-
-                    if status.contains("install") {
-                        summary.installed += 1;
-                    } else {
-                        summary.updated += 1;
-                    }
+                if is_unchanged {
+                    summary.unchanged += 1;
                     actions.push(Action {
                         source: Some(src.source.clone()),
                         skill: Some(format!("mcp:{file_name}")),
-                        status: status.into(),
+                        status: "unchanged".into(),
                         error: None,
                     });
-                    Ok(())
-                })?;
+                } else {
+                    pending.push(PendingMcp {
+                        source: src.source.clone(),
+                        mcp_path: mcp_path.clone(),
+                        file_name,
+                        hash,
+                        server_names,
+                        asset_id,
+                        is_new: existing.is_none(),
+                    });
+                }
                 Ok(())
             })();
             if let Err(e) = r {
                 summary.broken += 1;
                 actions.push(Action {
                     source: Some(src.source.clone()),
-                    skill: Some(format!("mcp:{file_name}")),
+                    skill: Some(format!("mcp:{file_name_err}")),
                     status: "broken".into(),
                     error: Some(e.to_string()),
                 });
             }
         }
+
         if let Some(d) = materialized.cleanup_dir {
-            let _ = fs::remove_dir_all(d);
+            cleanup_dirs.push(d);
         }
     }
 
-    // Remove MCP servers no longer in config
+    // Phase 2: prompt before registering new MCP servers (unless --no-confirm or dry-run).
+    if !ctx.dry_run && !ctx.no_confirm {
+        let new_servers: Vec<(&str, &str)> = pending
+            .iter()
+            .filter(|p| p.is_new)
+            .flat_map(|p| {
+                p.server_names
+                    .iter()
+                    .map(move |s| (s.as_str(), p.source.as_str()))
+            })
+            .collect();
+
+        if !new_servers.is_empty() && std::io::stdin().is_terminal() {
+            println!();
+            println!("New MCP servers to be registered:");
+            println!();
+            for (server, source) in &new_servers {
+                println!("  • {server}  (from {source})");
+            }
+            println!();
+            print!("Proceed? [y/N] ");
+            std::io::stdout().flush()?;
+
+            let mut input = String::new();
+            std::io::stdin().read_line(&mut input)?;
+            if input.trim().to_lowercase() != "y" {
+                for d in cleanup_dirs {
+                    let _ = fs::remove_dir_all(d);
+                }
+                return Ok(());
+            }
+        }
+    }
+
+    // Phase 3: apply pending operations.
+    for p in &pending {
+        let label = sync_label("MCP", &p.file_name, &p.source, ctx.plain);
+        let r: std::result::Result<(), crate::error::Error> =
+            with_spinner(ctx.animate, ctx.plain, &label, || {
+                let status = if p.is_new {
+                    if ctx.dry_run { "would_install" } else { "installed" }
+                } else if ctx.dry_run {
+                    "would_update"
+                } else {
+                    "updated"
+                };
+
+                if !ctx.dry_run {
+                    for target in &mcp_settings_list {
+                        merge_mcp_config(&p.mcp_path, target)?;
+                    }
+                    let servers_csv = p.server_names.join(",");
+                    lock.save_tracked_asset(
+                        "mcp",
+                        &p.asset_id,
+                        &p.file_name,
+                        &p.hash,
+                        &p.source,
+                        &servers_csv,
+                    );
+                }
+
+                if status.contains("install") {
+                    summary.installed += 1;
+                } else {
+                    summary.updated += 1;
+                }
+                actions.push(Action {
+                    source: Some(p.source.clone()),
+                    skill: Some(format!("mcp:{}", p.file_name)),
+                    status: status.into(),
+                    error: None,
+                });
+                Ok(())
+            });
+        if let Err(e) = r {
+            summary.broken += 1;
+            actions.push(Action {
+                source: Some(p.source.clone()),
+                skill: Some(format!("mcp:{}", p.file_name)),
+                status: "broken".into(),
+                error: Some(e.to_string()),
+            });
+        }
+    }
+
+    for d in cleanup_dirs {
+        let _ = fs::remove_dir_all(d);
+    }
+
+    // Remove MCP servers no longer in config.
     let existing_mcps: Vec<(String, String)> = lock
         .list_tracked_asset_ids("mcp")
         .iter()

--- a/src/commands/sync/mcps.rs
+++ b/src/commands/sync/mcps.rs
@@ -167,35 +167,55 @@ pub(super) fn sync_mcps(
     }
 
     // Phase 2: prompt before registering new MCP servers (unless --no-confirm or dry-run).
+    // "New" means not yet present in any settings target — catches both first-time packs
+    // and updated packs that gain additional server entries.
     if !ctx.dry_run && !ctx.no_confirm {
         let new_servers: Vec<(&str, &str)> = pending
             .iter()
-            .filter(|p| p.is_new)
             .flat_map(|p| {
-                p.server_names
-                    .iter()
-                    .map(move |s| (s.as_str(), p.source.as_str()))
+                p.server_names.iter().filter_map(|s| {
+                    let missing_from_any = !mcp_settings_list
+                        .iter()
+                        .all(|t| servers_present_in_settings(&[s.clone()], t));
+                    if missing_from_any {
+                        Some((s.as_str(), p.source.as_str()))
+                    } else {
+                        None
+                    }
+                })
             })
             .collect();
 
-        if !new_servers.is_empty() && std::io::stdin().is_terminal() {
-            println!();
-            println!("New MCP servers to be registered:");
-            println!();
-            for (server, source) in &new_servers {
-                println!("  • {server}  (from {source})");
-            }
-            println!();
-            print!("Proceed? [y/N] ");
-            std::io::stdout().flush()?;
+        if !new_servers.is_empty() {
+            if std::io::stdin().is_terminal() {
+                println!();
+                println!("New MCP servers to be registered:");
+                println!();
+                for (server, source) in &new_servers {
+                    println!("  • {server}  (from {source})");
+                }
+                println!();
+                print!("Proceed? [y/N] ");
+                std::io::stdout().flush()?;
 
-            let mut input = String::new();
-            std::io::stdin().read_line(&mut input)?;
-            if input.trim().to_lowercase() != "y" {
+                let mut input = String::new();
+                std::io::stdin().read_line(&mut input)?;
+                if input.trim().to_lowercase() != "y" {
+                    for d in cleanup_dirs {
+                        let _ = fs::remove_dir_all(d);
+                    }
+                    return Ok(());
+                }
+            } else {
+                // Non-interactive: refuse to register new servers without explicit opt-in.
+                // This prevents CI/scripts from silently expanding the MCP attack surface.
                 for d in cleanup_dirs {
                     let _ = fs::remove_dir_all(d);
                 }
-                return Ok(());
+                return Err(crate::error::err(
+                    "new MCP servers would be registered in a non-interactive session; \
+                     pass --no-confirm to allow this",
+                ));
             }
         }
     }

--- a/src/commands/sync/mod.rs
+++ b/src/commands/sync/mod.rs
@@ -22,6 +22,7 @@ pub(super) struct SyncContext<'a> {
     pub(super) plain: bool,
     pub(super) as_json: bool,
     pub(super) quiet: bool,
+    pub(super) no_confirm: bool,
 }
 
 /// Options for the `sync` command.
@@ -32,6 +33,7 @@ pub(crate) struct SyncOptions<'a> {
     pub as_json: bool,
     pub plain: bool,
     pub verbose: bool,
+    pub no_confirm: bool,
     pub scope_override: Option<Scope>,
     pub show_banner: bool,
 }
@@ -66,6 +68,7 @@ pub(crate) fn run(opts: &SyncOptions) -> Result<()> {
         plain: opts.plain,
         as_json: opts.as_json,
         quiet: opts.quiet,
+        no_confirm: opts.no_confirm,
     };
 
     let mut lock = load_lock(scope, &cfg_dir)?;

--- a/src/home/mod.rs
+++ b/src/home/mod.rs
@@ -35,6 +35,7 @@ pub(crate) fn run(program_name: &str, default_config: &str) -> Result<()> {
                 as_json: sync.json,
                 plain: sync.plain,
                 verbose: sync.verbose,
+                no_confirm: sync.no_confirm,
                 scope_override: sync.scope.scope_override(),
                 show_banner: true,
             })


### PR DESCRIPTION
- self update now downloads checksums.txt from the same GitHub release and
  verifies the SHA256 of the tarball before extracting, matching the
  behaviour already present in install.sh
- kst sync now prompts for confirmation before registering new MCP servers
  into agent configs; pass --no-confirm to skip the prompt (e.g. in CI)
- the MCP sync logic is restructured into three phases: discover, prompt,
  apply — keeping temp dirs alive across phases so paths remain valid
