### PR TITLE
feat(security): add self-update checksum verification and MCP approval gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ CLI args → match cli.command
 1. Load config from file or HTTP URL (with GitLab/GitHub/Gitea auth via env vars)
 2. Resolve scope (CLI flag → config field → default Global) and destination paths per agent
 3. For each skill source: materialize (download if remote) → discover available skills → select targets → hash → copy → update lock state
-4. For each MCP source: materialize → discover/resolve packs → merge into agent settings files → update lock
+4. For each MCP source: materialize → discover/resolve packs → collect pending installs → prompt for confirmation if new servers found (unless `--yes`) → merge into agent settings files → update lock
 5. Save lock file and report (unless `--dry-run`)
 
 ### UI System

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ kst init [--global] [--force]
 Reads the config, discovers skills, and makes the local destination match.
 
 ```bash
-kst sync [--config <path-or-url>] [--dry-run] [--quiet] [--json] [--plain] [--verbose] [--project | --global]
+kst sync [--config <path-or-url>] [--dry-run] [--quiet] [--json] [--plain] [--verbose] [--yes] [--project | --global]
 ```
 
 | Flag        | What it does                                                 |
@@ -132,6 +132,7 @@ kst sync [--config <path-or-url>] [--dry-run] [--quiet] [--json] [--plain] [--ve
 | `--json`    | Print the sync report as JSON                                |
 | `--plain`   | Disable colors and spinner animations                        |
 | `--verbose` | Show per-skill action details                                |
+| `--yes`     | Skip confirmation prompt for new MCP servers                 |
 | `--project` | Install into the current project directory                   |
 | `--global`  | Install globally (default)                                   |
 
@@ -174,7 +175,7 @@ kst clean [--dry-run] [--json] [--quiet] [--plain] [--project | --global]
 
 ### `kst self update`
 
-Checks GitHub for the latest release and replaces the current binary in-place.
+Checks GitHub for the latest release, verifies the SHA256 checksum against `checksums.txt`, and replaces the current binary in-place.
 
 ```bash
 kst self update [--json]

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,6 +33,7 @@ kst sync [OPTIONS]
 | `--json`                 | Print the sync report as JSON                                |
 | `--plain`                | Disable colors and spinner animations                        |
 | `--verbose`              | Show per-skill action details                                |
+| `--yes`                  | Skip confirmation prompt for new MCP servers                 |
 | `--project`              | Install into the current project directory                   |
 | `--global`               | Install globally (default)                                   |
 
@@ -112,7 +113,7 @@ Manage Kasetto itself — update to a new version or remove it completely.
 
 ### `kst self update`
 
-Fetches the latest release from GitHub and swaps out the binary in-place.
+Fetches the latest release from GitHub, verifies the SHA256 checksum against `checksums.txt` from the same release, and swaps out the binary in-place.
 
 ```bash
 kst self update [OPTIONS]

--- a/docs/security.md
+++ b/docs/security.md
@@ -24,6 +24,26 @@ Kasetto is designed around a "tracked-only" principle:
 
 See [How Sync Works](./how-sync-works.md) for details.
 
+## MCP Server Approval Gate
+
+When `kst sync` discovers **new** MCP servers that haven't been registered before, it lists them and asks for confirmation before writing them into your agent configs:
+
+```
+The following MCP servers will be registered:
+  - git-tools
+  - code-search
+
+Proceed? [y/N]
+```
+
+Updates to already-registered servers are applied without prompting. Use `--yes` to skip the prompt (e.g. in CI), or `--dry-run` to preview without writing.
+
+In non-interactive mode (piped stdin), sync will error unless `--yes` is passed — this prevents unreviewed MCP registration in automated pipelines.
+
+## Self-Update Integrity
+
+`kst self update` verifies the downloaded binary against `checksums.txt` from the same GitHub release using SHA256 — the same verification the shell installer (`install.sh`) performs. If the checksum doesn't match, the update is aborted and the existing binary is left untouched.
+
 ## What Kasetto Does Not Do
 
 - It does not run skill code.

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,6 +21,7 @@ pub fn run() -> Result<()> {
                     as_json: sync.json,
                     plain: sync.plain,
                     verbose: sync.verbose,
+                    yes: sync.yes,
                     scope_override: sync.scope.scope_override(),
                     show_banner: true,
                 })

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,6 +82,9 @@ pub(crate) struct SyncArgs {
     #[arg(long)]
     #[arg(help = "print per-skill action list")]
     pub verbose: bool,
+    #[arg(long)]
+    #[arg(help = "skip confirmation prompt for new MCP servers")]
+    pub yes: bool,
     #[command(flatten)]
     pub scope: ScopeArgs,
 }

--- a/src/commands/self_update.rs
+++ b/src/commands/self_update.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::io::IsTerminal;
 
+use sha2::{Digest, Sha256};
+
 use crate::banner::print_banner_or_plain;
 use crate::colors::{ACCENT, RESET, SECONDARY, SUCCESS};
 use crate::error::{err, Result};
@@ -82,8 +84,15 @@ pub(crate) fn run(as_json: bool) -> Result<()> {
         format!("Updating {} -> {}", current_version, latest_version)
     };
 
+    let checksums_asset = release.assets.iter().find(|a| a.name == "checksums.txt");
+
     with_spinner(animate, !color, &update_label, || {
-        self_replace(&asset.browser_download_url, &current_exe)
+        self_replace(
+            &asset.browser_download_url,
+            &asset.name,
+            checksums_asset.map(|a| a.browser_download_url.as_str()),
+            &current_exe,
+        )
     })?;
 
     let output = UpdateOutput {
@@ -143,13 +152,30 @@ fn is_newer(current: &str, latest: &str) -> bool {
     parse(latest) > parse(current)
 }
 
-fn self_replace(url: &str, exe_path: &std::path::Path) -> Result<()> {
+fn self_replace(
+    url: &str,
+    asset_name: &str,
+    checksums_url: Option<&str>,
+    exe_path: &std::path::Path,
+) -> Result<()> {
     let body = http_client()?
         .get(url)
         .send()?
         .error_for_status()
         .map_err(|e| err(format!("failed to download update: {e}")))?
         .bytes()?;
+
+    // Verify SHA256 checksum when checksums.txt is available in the release
+    if let Some(checksums_url) = checksums_url {
+        let checksums_text = http_client()?
+            .get(checksums_url)
+            .send()
+            .and_then(|r| r.error_for_status())
+            .and_then(|r| r.text())
+            .map_err(|e| err(format!("failed to download checksums.txt: {e}")))?;
+
+        verify_checksum(&body, asset_name, &checksums_text)?;
+    }
 
     let gz = flate2::read::GzDecoder::new(body.as_ref());
     let mut archive = tar::Archive::new(gz);
@@ -205,6 +231,28 @@ fn self_replace(url: &str, exe_path: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
+/// Verify that the SHA256 of `data` matches the expected hash for `asset_name`
+/// found in the checksums text (one `<hash>  <filename>` per line).
+fn verify_checksum(data: &[u8], asset_name: &str, checksums_text: &str) -> Result<()> {
+    let expected = checksums_text
+        .lines()
+        .find(|line| line.ends_with(asset_name))
+        .and_then(|line| line.split_whitespace().next())
+        .ok_or_else(|| {
+            err(format!(
+                "checksum not found for {asset_name} in checksums.txt"
+            ))
+        })?;
+
+    let actual = format!("{:x}", Sha256::digest(data));
+    if actual != expected {
+        return Err(err(format!(
+            "checksum mismatch for {asset_name}: expected {expected}, got {actual}"
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -238,5 +286,43 @@ mod tests {
     fn current_target_returns_nonempty_string() {
         let target = current_target();
         assert!(!target.is_empty());
+    }
+
+    #[test]
+    fn verify_checksum_passes_on_match() {
+        let data = b"hello world";
+        let hash = format!("{:x}", Sha256::digest(data));
+        let checksums = format!("{hash}  kasetto-aarch64-apple-darwin.tar.gz\n");
+        verify_checksum(data, "kasetto-aarch64-apple-darwin.tar.gz", &checksums).unwrap();
+    }
+
+    #[test]
+    fn verify_checksum_fails_on_mismatch() {
+        let data = b"hello world";
+        let checksums = "0000000000000000000000000000000000000000000000000000000000000000  kasetto-aarch64-apple-darwin.tar.gz\n";
+        let result = verify_checksum(data, "kasetto-aarch64-apple-darwin.tar.gz", checksums);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("checksum mismatch"));
+    }
+
+    #[test]
+    fn verify_checksum_fails_when_asset_not_in_checksums() {
+        let data = b"hello world";
+        let checksums = "abcdef1234567890  kasetto-x86_64-unknown-linux-gnu.tar.gz\n";
+        let result = verify_checksum(data, "kasetto-aarch64-apple-darwin.tar.gz", checksums);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("checksum not found"));
+    }
+
+    #[test]
+    fn verify_checksum_handles_multiple_entries() {
+        let data = b"binary content";
+        let hash = format!("{:x}", Sha256::digest(data));
+        let checksums = format!(
+            "aaaa  kasetto-x86_64-unknown-linux-gnu.tar.gz\n{hash}  kasetto-aarch64-apple-darwin.tar.gz\nbbbb  kasetto-x86_64-apple-darwin.tar.gz\n"
+        );
+        verify_checksum(data, "kasetto-aarch64-apple-darwin.tar.gz", &checksums).unwrap();
     }
 }

--- a/src/commands/sync/mcps.rs
+++ b/src/commands/sync/mcps.rs
@@ -1,7 +1,10 @@
 use std::collections::HashSet;
 use std::fs;
+use std::io::{self, IsTerminal, Write};
+use std::path::PathBuf;
 
-use crate::error::Result;
+use crate::colors::{ACCENT, RESET, SECONDARY, WARNING};
+use crate::error::{err, Result};
 use crate::fsops::{hash_file, now_unix, resolve_mcp_settings_targets};
 use crate::lock::LockFile;
 use crate::mcps::{merge_mcp_config, remove_mcp_server, servers_present_in_settings};
@@ -10,6 +13,17 @@ use crate::source::{discover_mcps, materialize_source, resolve_mcp_path};
 use crate::ui::with_spinner;
 
 use super::{file_name_str, sync_label, SyncContext};
+
+/// An MCP entry ready to be installed or updated.
+struct PendingMcp {
+    source: String,
+    file_name: String,
+    mcp_path: PathBuf,
+    hash: String,
+    server_names: Vec<String>,
+    asset_id: String,
+    is_new: bool,
+}
 
 pub(super) fn sync_mcps(
     ctx: &SyncContext,
@@ -22,6 +36,10 @@ pub(super) fn sync_mcps(
     if mcp_settings_list.is_empty() {
         return Ok(());
     }
+
+    // Phase 1: discover and classify all MCP entries
+    let mut pending: Vec<PendingMcp> = Vec::new();
+    let mut cleanup_dirs: Vec<PathBuf> = Vec::new();
 
     for (i, src) in ctx.cfg.mcps.iter().enumerate() {
         let stage = std::env::temp_dir().join(format!("kasetto-mcp-{}-{}", now_unix(), i));
@@ -85,6 +103,7 @@ pub(super) fn sync_mcps(
         }
         for mcp_path in &mcps {
             let file_name = file_name_str(mcp_path);
+            let file_name_for_err = file_name.clone();
             let r: std::result::Result<(), crate::error::Error> = (|| {
                 let hash = hash_file(mcp_path)?;
                 let mcp_text = fs::read_to_string(mcp_path)?;
@@ -109,9 +128,9 @@ pub(super) fn sync_mcps(
                     })
                     .unwrap_or(false);
 
-                let label = sync_label("MCP", &file_name, &src.source, ctx.plain);
-                with_spinner(ctx.animate, ctx.plain, &label, || {
-                    if is_unchanged {
+                if is_unchanged {
+                    let label = sync_label("MCP", &file_name, &src.source, ctx.plain);
+                    with_spinner(ctx.animate, ctx.plain, &label, || {
                         summary.unchanged += 1;
                         actions.push(Action {
                             source: Some(src.source.clone()),
@@ -119,67 +138,170 @@ pub(super) fn sync_mcps(
                             status: "unchanged".into(),
                             error: None,
                         });
-                        return Ok(());
-                    }
-
-                    let status = if existing.is_some() {
-                        if ctx.dry_run {
-                            "would_update"
-                        } else {
-                            "updated"
-                        }
-                    } else if ctx.dry_run {
-                        "would_install"
-                    } else {
-                        "installed"
-                    };
-
-                    if !ctx.dry_run {
-                        for target in &mcp_settings_list {
-                            merge_mcp_config(mcp_path, target)?;
-                        }
-                        let servers_csv = server_names.join(",");
-                        lock.save_tracked_asset(
-                            "mcp",
-                            &asset_id,
-                            &file_name,
-                            &hash,
-                            &src.source,
-                            &servers_csv,
-                        );
-                    }
-
-                    if status.contains("install") {
-                        summary.installed += 1;
-                    } else {
-                        summary.updated += 1;
-                    }
-                    actions.push(Action {
-                        source: Some(src.source.clone()),
-                        skill: Some(format!("mcp:{file_name}")),
-                        status: status.into(),
-                        error: None,
+                        Ok(())
+                    })?;
+                } else {
+                    pending.push(PendingMcp {
+                        source: src.source.clone(),
+                        file_name,
+                        mcp_path: mcp_path.clone(),
+                        hash,
+                        server_names,
+                        asset_id,
+                        is_new: existing.is_none(),
                     });
-                    Ok(())
-                })?;
+                }
                 Ok(())
             })();
             if let Err(e) = r {
                 summary.broken += 1;
                 actions.push(Action {
                     source: Some(src.source.clone()),
-                    skill: Some(format!("mcp:{file_name}")),
+                    skill: Some(format!("mcp:{file_name_for_err}")),
                     status: "broken".into(),
                     error: Some(e.to_string()),
                 });
             }
         }
+        // Defer cleanup so mcp_path references remain valid
         if let Some(d) = materialized.cleanup_dir {
-            let _ = fs::remove_dir_all(d);
+            cleanup_dirs.push(d);
         }
     }
 
+    // Phase 2: prompt for confirmation when new MCP servers will be registered
+    let new_servers: Vec<&PendingMcp> = pending.iter().filter(|p| p.is_new).collect();
+    if !new_servers.is_empty() && !ctx.dry_run && !ctx.yes {
+        let all_names: Vec<&str> = new_servers
+            .iter()
+            .flat_map(|p| p.server_names.iter().map(|s| s.as_str()))
+            .collect();
+
+        if !all_names.is_empty() {
+            let approved = confirm_new_mcps(&all_names, ctx.plain)?;
+            if !approved {
+                // User declined — mark new installs as skipped, still apply updates
+                for p in &pending {
+                    if p.is_new {
+                        actions.push(Action {
+                            source: Some(p.source.clone()),
+                            skill: Some(format!("mcp:{}", p.file_name)),
+                            status: "skipped".into(),
+                            error: None,
+                        });
+                    }
+                }
+                // Only keep updates
+                let pending_updates: Vec<PendingMcp> =
+                    pending.into_iter().filter(|p| !p.is_new).collect();
+                apply_pending(
+                    ctx,
+                    lock,
+                    summary,
+                    actions,
+                    &mcp_settings_list,
+                    &pending_updates,
+                )?;
+                cleanup_staged(&cleanup_dirs);
+                remove_stale(
+                    ctx,
+                    lock,
+                    summary,
+                    actions,
+                    &desired_mcp_ids,
+                    &mcp_settings_list,
+                );
+                return Ok(());
+            }
+        }
+    }
+
+    // Phase 3: apply all pending installs and updates
+    apply_pending(ctx, lock, summary, actions, &mcp_settings_list, &pending)?;
+    cleanup_staged(&cleanup_dirs);
+
     // Remove MCP servers no longer in config
+    remove_stale(
+        ctx,
+        lock,
+        summary,
+        actions,
+        &desired_mcp_ids,
+        &mcp_settings_list,
+    );
+
+    Ok(())
+}
+
+fn apply_pending(
+    ctx: &SyncContext,
+    lock: &mut LockFile,
+    summary: &mut Summary,
+    actions: &mut Vec<Action>,
+    mcp_settings_list: &[crate::model::McpSettingsTarget],
+    pending: &[PendingMcp],
+) -> Result<()> {
+    for p in pending {
+        let label = sync_label("MCP", &p.file_name, &p.source, ctx.plain);
+        with_spinner(ctx.animate, ctx.plain, &label, || {
+            let status = if !p.is_new {
+                if ctx.dry_run {
+                    "would_update"
+                } else {
+                    "updated"
+                }
+            } else if ctx.dry_run {
+                "would_install"
+            } else {
+                "installed"
+            };
+
+            if !ctx.dry_run {
+                for target in mcp_settings_list {
+                    merge_mcp_config(&p.mcp_path, target)?;
+                }
+                let servers_csv = p.server_names.join(",");
+                lock.save_tracked_asset(
+                    "mcp",
+                    &p.asset_id,
+                    &p.file_name,
+                    &p.hash,
+                    &p.source,
+                    &servers_csv,
+                );
+            }
+
+            if status.contains("install") {
+                summary.installed += 1;
+            } else {
+                summary.updated += 1;
+            }
+            actions.push(Action {
+                source: Some(p.source.clone()),
+                skill: Some(format!("mcp:{}", p.file_name)),
+                status: status.into(),
+                error: None,
+            });
+            Ok(())
+        })?;
+    }
+    Ok(())
+}
+
+fn cleanup_staged(dirs: &[PathBuf]) {
+    for d in dirs {
+        let _ = fs::remove_dir_all(d);
+    }
+}
+
+fn remove_stale(
+    ctx: &SyncContext,
+    lock: &mut LockFile,
+    summary: &mut Summary,
+    actions: &mut Vec<Action>,
+    desired_mcp_ids: &HashSet<String>,
+    mcp_settings_list: &[crate::model::McpSettingsTarget],
+) {
     let existing_mcps: Vec<(String, String)> = lock
         .list_tracked_asset_ids("mcp")
         .iter()
@@ -199,7 +321,7 @@ pub(super) fn sync_mcps(
                 error: None,
             });
         } else {
-            for target in &mcp_settings_list {
+            for target in mcp_settings_list {
                 for server_name in old_servers_csv.split(',').filter(|s| !s.is_empty()) {
                     let _ = remove_mcp_server(server_name, target);
                 }
@@ -214,6 +336,99 @@ pub(super) fn sync_mcps(
             });
         }
     }
+}
 
-    Ok(())
+/// Prompt the user to confirm registration of new MCP servers.
+/// Returns `true` if approved, `false` if declined.
+/// Errors in non-interactive mode (piped stdin) to prevent unreviewed registration.
+fn confirm_new_mcps(server_names: &[&str], plain: bool) -> Result<bool> {
+    if !io::stdin().is_terminal() {
+        return Err(err(
+            "new MCP servers would be registered but stdin is not a terminal; pass --yes to confirm",
+        ));
+    }
+
+    println!();
+    if plain {
+        println!("The following MCP servers will be registered:");
+    } else {
+        println!("{WARNING}The following MCP servers will be registered:{RESET}");
+    }
+    for name in server_names {
+        if plain {
+            println!("  - {name}");
+        } else {
+            println!("  {SECONDARY}-{RESET} {ACCENT}{name}{RESET}");
+        }
+    }
+    println!();
+
+    if plain {
+        print!("Proceed? [y/N] ");
+    } else {
+        print!("{ACCENT}Proceed?{RESET} [y/N] ");
+    }
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    Ok(matches!(input.trim(), "y" | "Y" | "yes"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_mcp_classification_new_vs_update() {
+        let new_entry = PendingMcp {
+            source: "https://github.com/org/pack".into(),
+            file_name: "mcp.json".into(),
+            mcp_path: PathBuf::from("/tmp/mcp.json"),
+            hash: "abc123".into(),
+            server_names: vec!["server-a".into(), "server-b".into()],
+            asset_id: "mcp::source::mcp.json".into(),
+            is_new: true,
+        };
+        let update_entry = PendingMcp {
+            source: "https://github.com/org/pack".into(),
+            file_name: "other.json".into(),
+            mcp_path: PathBuf::from("/tmp/other.json"),
+            hash: "def456".into(),
+            server_names: vec!["server-c".into()],
+            asset_id: "mcp::source::other.json".into(),
+            is_new: false,
+        };
+
+        let pending = vec![new_entry, update_entry];
+        let new_servers: Vec<&PendingMcp> = pending.iter().filter(|p| p.is_new).collect();
+
+        assert_eq!(new_servers.len(), 1);
+        assert_eq!(new_servers[0].server_names, vec!["server-a", "server-b"]);
+
+        let all_names: Vec<&str> = new_servers
+            .iter()
+            .flat_map(|p| p.server_names.iter().map(|s| s.as_str()))
+            .collect();
+        assert_eq!(all_names, vec!["server-a", "server-b"]);
+    }
+
+    #[test]
+    fn pending_mcp_no_new_servers_skips_gate() {
+        let update_only = vec![PendingMcp {
+            source: "https://github.com/org/pack".into(),
+            file_name: "mcp.json".into(),
+            mcp_path: PathBuf::from("/tmp/mcp.json"),
+            hash: "abc123".into(),
+            server_names: vec!["existing-server".into()],
+            asset_id: "mcp::source::mcp.json".into(),
+            is_new: false,
+        }];
+
+        let new_servers: Vec<&PendingMcp> = update_only.iter().filter(|p| p.is_new).collect();
+        assert!(
+            new_servers.is_empty(),
+            "updates should not trigger the gate"
+        );
+    }
 }

--- a/src/commands/sync/mod.rs
+++ b/src/commands/sync/mod.rs
@@ -18,6 +18,7 @@ pub(super) struct SyncContext<'a> {
     pub(super) destinations: &'a [PathBuf],
     pub(super) scope: Scope,
     pub(super) dry_run: bool,
+    pub(super) yes: bool,
     pub(super) animate: bool,
     pub(super) plain: bool,
     pub(super) as_json: bool,
@@ -32,6 +33,7 @@ pub(crate) struct SyncOptions<'a> {
     pub as_json: bool,
     pub plain: bool,
     pub verbose: bool,
+    pub yes: bool,
     pub scope_override: Option<Scope>,
     pub show_banner: bool,
 }
@@ -62,6 +64,7 @@ pub(crate) fn run(opts: &SyncOptions) -> Result<()> {
         destinations: &destinations,
         scope,
         dry_run: opts.dry_run,
+        yes: opts.yes,
         animate,
         plain: opts.plain,
         as_json: opts.as_json,

--- a/src/home/mod.rs
+++ b/src/home/mod.rs
@@ -35,6 +35,7 @@ pub(crate) fn run(program_name: &str, default_config: &str) -> Result<()> {
                 as_json: sync.json,
                 plain: sync.plain,
                 verbose: sync.verbose,
+                yes: false,
                 scope_override: sync.scope.scope_override(),
                 show_banner: true,
             })


### PR DESCRIPTION
## Summary

- **Self-update checksum verification**: `kst self update` now verifies SHA256 of the downloaded binary against `checksums.txt` from the same GitHub release before replacing the executable, matching the integrity check the shell installer already performs
- **MCP approval gate**: `kst sync` now prompts for confirmation before registering new MCP servers into agent configs. Updates to existing servers bypass the prompt. `--yes` flag skips the prompt for CI/scripting
- Updated README, CLAUDE.md, docs/commands.md, and docs/security.md to document both features

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — 99 tests pass (93 existing + 6 new)
- [x] `cargo clippy` — no warnings
- [x] Manual: run `kst self update` on a release with `checksums.txt` — verify checksum passes
- [x] Manual: run `kst self update` with a tampered binary — verify abort on mismatch
- [x] Manual: run `kst sync` with new MCP sources — verify confirmation prompt appears
- [x] Manual: run `kst sync --yes` — verify prompt is skipped
- [x] Manual: pipe `kst sync` (non-TTY) without `--yes` — verify error message

Closes #15