### PR TITLE
feat(sync): support root SKILL.md and source sub-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,11 @@ skills:
       - name: custom-skill
         path: tools/skills
 
+  # Scope discovery to a nested directory inside the source
+  - source: https://github.com/acme/agents
+    sub-dir: plugins/swift-apple-expert
+    skills: "*"
+
 # MCP servers (optional)
 mcps:
   - source: https://github.com/org/mcp-pack
@@ -259,6 +264,7 @@ mcps:
 | `skills[].source` | **yes**  | Git host URL or local path                                          |
 | `skills[].branch` | no       | Branch for remote sources (default: `main`, falls back to `master`) |
 | `skills[].ref`    | no       | Git tag, commit SHA, or ref (takes priority over `branch`)          |
+| `skills[].sub-dir`| no       | Relative subdirectory to use as source root (`sub_dir` alias also supported) |
 | `skills[].skills` | **yes**  | `"*"` for all, or a list of names / `{ name, path }` objects        |
 | `mcps`            | no       | List of MCP server sources                                          |
 | `mcps[].source`   | **yes**  | Git host URL or local path containing MCP config                    |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,11 @@ skills:
       - name: custom-skill
         path: tools/skills
 
+  # Limit discovery to a nested directory inside the source
+  - source: https://github.com/acme/agents
+    sub-dir: plugins/swift-apple-expert
+    skills: "*"
+
 # MCP servers (optional)
 mcps:
   - source: https://github.com/org/mcp-pack
@@ -65,12 +70,13 @@ mcps:
 
 ### Skill Source Fields
 
-| Key      | Required | Description                                                            |
-| -------- | -------- | ---------------------------------------------------------------------- |
-| `source` | **yes**  | Git host URL or local path (GitHub, GitLab, Bitbucket, Codeberg/Gitea) |
-| `branch` | no       | Branch for remote sources (default: `main`, falls back to `master`)    |
-| `ref`    | no       | Git tag, commit SHA, or ref - takes priority over `branch`             |
-| `skills` | **yes**  | `"*"` for all, or a list of names / `{ name, path }` objects           |
+| Key       | Required | Description                                                            |
+| --------- | -------- | ---------------------------------------------------------------------- |
+| `source`  | **yes**  | Git host URL or local path (GitHub, GitLab, Bitbucket, Codeberg/Gitea) |
+| `branch`  | no       | Branch for remote sources (default: `main`, falls back to `master`)    |
+| `ref`     | no       | Git tag, commit SHA, or ref - takes priority over `branch`             |
+| `sub-dir` | no       | Relative subdirectory within the source used as the discovery root (`sub_dir` alias supported) |
+| `skills`  | **yes**  | `"*"` for all, or a list of names / `{ name, path }` objects           |
 
 ### Skill Entry Fields
 

--- a/docs/how-sync-works.md
+++ b/docs/how-sync-works.md
@@ -24,11 +24,15 @@ A look at what `kst sync` actually does — how skills are installed, how MCP co
 
 Skills are plain directories with a `SKILL.md` file (see [writing skills](./writing-skills.md)). On each sync, Kasetto:
 
-- **Discovers** skills by scanning the source root and `skills/` subdirectory for directories
-  that contain a `SKILL.md` file.
+- **Resolves** the source root (optionally via `sub-dir`).
+- **Discovers** skills from:
+  - top-level `SKILL.md` in the resolved root,
+  - root-level subdirectories with `SKILL.md`, and
+  - `skills/<name>/SKILL.md`.
 - **Hashes** the source skill directory.
 - **Compares** the hash to the lock file. If unchanged, the skill is skipped.
-- **Copies** the entire directory to the destination, replacing any previous version.
+- **Copies** the entire directory to the destination, replacing any previous version (including
+  symlinked files/directories inside the skill).
 - **Removes** skill directories that are no longer listed in the config.
 
 Skills are fully replaced on update — no partial merges.

--- a/docs/writing-skills.md
+++ b/docs/writing-skills.md
@@ -4,10 +4,11 @@ Skills are just directories with a `SKILL.md` file inside. Here's how to structu
 
 ## Directory Layout
 
-Kasetto looks in two places within a source:
+Kasetto discovers skills from the source root and from `skills/`:
 
 ```
 repo-root/
+├── SKILL.md                ← discovered as repo-name skill
 ├── my-skill/
 │   └── SKILL.md        ← discovered
 ├── skills/
@@ -18,7 +19,13 @@ repo-root/
 └── README.md           ← ignored (no SKILL.md)
 ```
 
-Any subdirectory at the root or inside `skills/` that contains a `SKILL.md` is picked up as a skill. The directory name is used as the skill's identifier.
+Kasetto picks up:
+
+- A top-level `SKILL.md` (installed using the repo name, or `sub-dir` basename).
+- Any root-level subdirectory containing `SKILL.md`.
+- Any `skills/<name>/SKILL.md` subdirectory.
+
+Directory names are used as skill identifiers for folder-based skills.
 
 !!! important
 
@@ -95,3 +102,16 @@ skills:
       - name: my-skill
         path: tools/ai-skills    # looks in tools/ai-skills/my-skill/SKILL.md
 ```
+
+## Limiting Discovery to a Nested Directory
+
+If your skills live under a nested plugin folder, set `sub-dir` on the source:
+
+```yaml
+skills:
+  - source: https://github.com/acme/agents
+    sub-dir: plugins/swift-apple-expert
+    skills: "*"
+```
+
+Kasetto treats `plugins/swift-apple-expert` as the source root for discovery.

--- a/src/fsops/copy.rs
+++ b/src/fsops/copy.rs
@@ -17,19 +17,69 @@ fn copy_dir_contents(src: &Path, dst: &Path) -> Result<()> {
         let entry = entry?;
         let src_path = entry.path();
         let target = dst.join(entry.file_name());
-        if entry.file_type()?.is_dir() {
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            let resolved = fs::canonicalize(&src_path)?;
+            let meta = fs::metadata(&resolved)?;
+            if meta.is_dir() {
+                fs::create_dir_all(&target)?;
+                copy_dir_contents(&resolved, &target)?;
+            } else {
+                copy_file(&resolved, &target)?;
+            }
+        } else if file_type.is_dir() {
             fs::create_dir_all(&target)?;
             copy_dir_contents(&src_path, &target)?;
         } else {
-            if let Some(parent) = target.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            let reader = BufReader::new(fs::File::open(&src_path)?);
-            let mut writer = BufWriter::new(fs::File::create(&target)?);
-            let mut buf_reader = reader;
-            std::io::copy(&mut buf_reader, &mut writer)?;
-            writer.flush()?;
+            copy_file(&src_path, &target)?;
         }
     }
     Ok(())
+}
+
+fn copy_file(src: &Path, dst: &Path) -> Result<()> {
+    if let Some(parent) = dst.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let reader = BufReader::new(fs::File::open(src)?);
+    let mut writer = BufWriter::new(fs::File::create(dst)?);
+    let mut buf_reader = reader;
+    std::io::copy(&mut buf_reader, &mut writer)?;
+    writer.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(prefix: &str) -> std::path::PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{}-{nonce}", std::process::id()))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_dir_follows_symlinked_directories() {
+        use std::os::unix::fs::symlink;
+
+        let src = temp_dir("kasetto-copy-src");
+        let refs_dir = src.join("references");
+        fs::create_dir_all(&refs_dir).expect("create refs");
+        fs::write(refs_dir.join("guide.md"), "hello").expect("write file");
+        symlink("references", src.join("linked-references")).expect("create symlink");
+
+        let dst = temp_dir("kasetto-copy-dst");
+        copy_dir(&src, &dst).expect("copy dir");
+
+        assert!(dst.join("linked-references/guide.md").is_file());
+        assert!(dst.join("references/guide.md").is_file());
+
+        let _ = fs::remove_dir_all(&src);
+        let _ = fs::remove_dir_all(&dst);
+    }
 }

--- a/src/fsops/mod.rs
+++ b/src/fsops/mod.rs
@@ -410,11 +410,44 @@ skills:
     }
 
     #[test]
+    fn config_parses_sub_dir_field() {
+        let yaml = r#"
+agent: cursor
+skills:
+  - source: https://github.com/example/pack
+    sub-dir: plugins/swift-apple-expert
+    skills: "*"
+"#;
+        let cfg: Config = serde_yaml::from_str(yaml).expect("parse");
+        assert_eq!(
+            cfg.skills[0].sub_dir.as_deref(),
+            Some("plugins/swift-apple-expert")
+        );
+    }
+
+    #[test]
+    fn config_parses_sub_dir_alias() {
+        let yaml = r#"
+agent: cursor
+skills:
+  - source: https://github.com/example/pack
+    sub_dir: plugins/swift-apple-expert
+    skills: "*"
+"#;
+        let cfg: Config = serde_yaml::from_str(yaml).expect("parse");
+        assert_eq!(
+            cfg.skills[0].sub_dir.as_deref(),
+            Some("plugins/swift-apple-expert")
+        );
+    }
+
+    #[test]
     fn git_pin_priority_ref_over_branch() {
         let spec = crate::model::SourceSpec {
             source: "https://github.com/x/y".into(),
             branch: Some("dev".into()),
             git_ref: Some("v1.0".into()),
+            sub_dir: None,
             skills: SkillsField::Wildcard("*".into()),
         };
         assert!(
@@ -429,6 +462,7 @@ skills:
             source: "https://github.com/x/y".into(),
             branch: Some("dev".into()),
             git_ref: None,
+            sub_dir: None,
             skills: SkillsField::Wildcard("*".into()),
         };
         assert!(
@@ -443,6 +477,7 @@ skills:
             source: "https://github.com/x/y".into(),
             branch: None,
             git_ref: None,
+            sub_dir: None,
             skills: SkillsField::Wildcard("*".into()),
         };
         assert!(matches!(spec.git_pin(), GitPin::Default));

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -77,6 +77,10 @@ pub(crate) struct SourceSpec {
     /// When set, no main/master fallback is attempted.
     #[serde(rename = "ref")]
     pub git_ref: Option<String>,
+    /// Optional subdirectory inside the source repo/path to use as the skill root.
+    /// Supports both `sub-dir` and `sub_dir` YAML keys.
+    #[serde(default, rename = "sub-dir", alias = "sub_dir")]
+    pub sub_dir: Option<String>,
     pub skills: SkillsField,
 }
 
@@ -120,6 +124,7 @@ impl McpSourceSpec {
             source: self.source.clone(),
             branch: self.branch.clone(),
             git_ref: self.git_ref.clone(),
+            sub_dir: None,
             skills: SkillsField::Wildcard("*".to_string()),
         }
     }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use remote::rewrite_gitlab_raw_url;
 
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use crate::error::{err, Result};
 use crate::fsops::resolve_path;
@@ -27,6 +27,43 @@ fn repo_name_hint(parsed: &parse::RepoUrl) -> String {
         parse::RepoUrl::Bitbucket { repo_slug, .. } => repo_slug.clone(),
         parse::RepoUrl::Gitea { repo, .. } => repo.clone(),
     }
+}
+
+fn resolve_source_root(base_root: &Path, sub_dir: Option<&str>) -> Result<PathBuf> {
+    let Some(sub_dir) = sub_dir else {
+        return Ok(base_root.to_path_buf());
+    };
+
+    let trimmed = sub_dir.trim();
+    if trimmed.is_empty() {
+        return Err(err("skills source `sub-dir` cannot be empty"));
+    }
+
+    let rel = Path::new(trimmed);
+    if rel.is_absolute() {
+        return Err(err("skills source `sub-dir` must be relative"));
+    }
+    if rel
+        .components()
+        .any(|c| matches!(c, Component::ParentDir | Component::RootDir))
+    {
+        return Err(err("skills source `sub-dir` must not escape the source root"));
+    }
+
+    let resolved = base_root.join(rel);
+    if !resolved.exists() {
+        return Err(err(format!(
+            "skills source sub-dir not found: {}",
+            resolved.display()
+        )));
+    }
+    if !resolved.is_dir() {
+        return Err(err(format!(
+            "skills source sub-dir is not a directory: {}",
+            resolved.display()
+        )));
+    }
+    Ok(resolved)
 }
 
 pub(crate) fn materialize_source(
@@ -61,8 +98,16 @@ pub(crate) fn materialize_source(
             }
         };
 
-        let hint = repo_name_hint(&parsed);
-        let available = discover_with_root_name(stage, Some(hint.as_str()))?;
+        let source_root = resolve_source_root(stage, src.sub_dir.as_deref())?;
+        let hint = src
+            .sub_dir
+            .as_deref()
+            .and_then(|sub_dir| Path::new(sub_dir).file_name())
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .map(|name| name.to_string())
+            .unwrap_or_else(|| repo_name_hint(&parsed));
+        let available = discover_with_root_name(&source_root, Some(hint.as_str()))?;
         Ok(MaterializedSource {
             source_revision,
             available,
@@ -70,7 +115,8 @@ pub(crate) fn materialize_source(
         })
     } else {
         let root = resolve_path(cfg_dir, &src.source);
-        let available = discover(&root)?;
+        let source_root = resolve_source_root(&root, src.sub_dir.as_deref())?;
+        let available = discover(&source_root)?;
         Ok(MaterializedSource {
             source_revision: "local".into(),
             available,
@@ -189,6 +235,7 @@ mod tests {
             source: root.to_string_lossy().to_string(),
             branch: None,
             git_ref: None,
+            sub_dir: None,
             skills: SkillsField::Wildcard("*".to_string()),
         };
         let stage = temp_dir("kasetto-stage");
@@ -198,6 +245,32 @@ mod tests {
         assert!(materialized.cleanup_dir.is_none());
         assert!(materialized.available.contains_key("demo-skill"));
         assert!(root.exists());
+
+        let _ = fs::remove_dir_all(&root);
+        let _ = fs::remove_dir_all(&stage);
+    }
+
+    #[test]
+    fn local_materialize_supports_sub_dir() {
+        let root = temp_dir("kasetto-local-subdir-src");
+        let nested = root.join("plugins/swift-apple-expert");
+        fs::create_dir_all(&nested).expect("create dirs");
+        fs::write(nested.join("SKILL.md"), "# Nested\n\nDesc\n").expect("write skill");
+
+        let src = SourceSpec {
+            source: root.to_string_lossy().to_string(),
+            branch: None,
+            git_ref: None,
+            sub_dir: Some("plugins/swift-apple-expert".to_string()),
+            skills: SkillsField::Wildcard("*".to_string()),
+        };
+
+        let stage = temp_dir("kasetto-stage-subdir");
+        let materialized =
+            materialize_source(&src, Path::new("/"), &stage).expect("materialize local subdir");
+
+        assert!(materialized.available.contains_key("swift-apple-expert"));
+        assert_eq!(materialized.available.get("swift-apple-expert").unwrap(), &nested);
 
         let _ = fs::remove_dir_all(&root);
         let _ = fs::remove_dir_all(&stage);

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -16,6 +16,19 @@ use crate::error::{err, Result};
 use crate::fsops::resolve_path;
 use crate::model::{GitPin, SourceSpec};
 
+fn repo_name_hint(parsed: &parse::RepoUrl) -> String {
+    match parsed {
+        parse::RepoUrl::GitHub { repo, .. } => repo.clone(),
+        parse::RepoUrl::GitLab { project_path, .. } => project_path
+            .split('/')
+            .next_back()
+            .unwrap_or(project_path)
+            .to_string(),
+        parse::RepoUrl::Bitbucket { repo_slug, .. } => repo_slug.clone(),
+        parse::RepoUrl::Gitea { repo, .. } => repo.clone(),
+    }
+}
+
 pub(crate) fn materialize_source(
     src: &SourceSpec,
     cfg_dir: &Path,
@@ -48,7 +61,8 @@ pub(crate) fn materialize_source(
             }
         };
 
-        let available = discover(stage)?;
+        let hint = repo_name_hint(&parsed);
+        let available = discover_with_root_name(stage, Some(hint.as_str()))?;
         Ok(MaterializedSource {
             source_revision,
             available,
@@ -72,7 +86,20 @@ pub(crate) struct MaterializedSource {
 }
 
 pub(crate) fn discover(root: &Path) -> Result<HashMap<String, PathBuf>> {
+    let root_name = root.file_name().and_then(|name| name.to_str());
+    discover_with_root_name(root, root_name)
+}
+
+fn discover_with_root_name(
+    root: &Path,
+    root_name: Option<&str>,
+) -> Result<HashMap<String, PathBuf>> {
     let mut out = HashMap::new();
+    if root.join("SKILL.md").is_file() {
+        if let Some(name) = root_name.filter(|name| !name.is_empty()) {
+            out.insert(name.to_string(), root.to_path_buf());
+        }
+    }
     discover_skills_in_subdir(root, &mut out)?;
     discover_skills_in_subdir(&root.join("skills"), &mut out)?;
     Ok(out)
@@ -174,6 +201,38 @@ mod tests {
 
         let _ = fs::remove_dir_all(&root);
         let _ = fs::remove_dir_all(&stage);
+    }
+
+    #[test]
+    fn discover_supports_root_level_skill_with_hint() {
+        let root = temp_dir("kasetto-root-skill");
+        fs::create_dir_all(&root).expect("create dirs");
+        fs::write(root.join("SKILL.md"), "# Root\n\nDesc\n").expect("write skill");
+
+        let available =
+            discover_with_root_name(&root, Some("raycast-script-creator")).expect("discover");
+        assert!(available.contains_key("raycast-script-creator"));
+        assert_eq!(available.get("raycast-script-creator").unwrap(), &root);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn discover_uses_local_directory_name_for_root_level_skill() {
+        let root = temp_dir("kasetto-root-skill-local");
+        fs::create_dir_all(&root).expect("create dirs");
+        fs::write(root.join("SKILL.md"), "# Root\n\nDesc\n").expect("write skill");
+
+        let available = discover(&root).expect("discover");
+        let root_name = root
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        assert!(available.contains_key(&root_name));
+        assert_eq!(available.get(&root_name).unwrap(), &root);
+
+        let _ = fs::remove_dir_all(&root);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- support root-level skill packs by discovering `SKILL.md` at the source root for both remote and local sources
- add `skills[].sub-dir` (with `sub_dir` alias) so a source can target a nested directory such as `plugins/<skill>` before discovery
- fix sync copy behavior for symlinked files/directories inside skills to avoid `Is a directory` failures
- update docs (README + docs site) to describe root-level discovery, `sub-dir`, and sync behavior

## Why
Some skill repositories are not laid out as `root/<skill>/SKILL.md` or `root/skills/<skill>/SKILL.md`:
- some expose a skill directly at repo root (`root/SKILL.md`)
- some keep skills under deeper monorepo paths and need a source-level subdirectory selector
- some include symlinked content inside skill folders

This PR makes those layouts first-class and keeps existing behavior unchanged for standard packs.

## Validation
- `cargo test root_level_skill`
- `cargo test copy_dir_follows_symlinked_directories`
- `cargo test sub_dir`
- `cargo test local_materialize_supports_sub_dir`
- `just check`