### PR TITLE
feat(config): Support reusable skill presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ When `--config` is omitted, Kasetto looks for config in this order:
 Point it at a specific file or URL with `--config`, or run `kst init` for local `./kasetto.yaml` (`kst init --global` writes the global config file).
 To persist a remote URL as your default, add a `source:` key to `~/.config/kasetto/config.yaml`.
 
+You can also define reusable `presets` in the global config and pull them into a repo config with `include_presets`.
+
 ```yaml
 # Choose an agent preset (single or multiple)...
 agent: codex
@@ -223,6 +225,17 @@ agent: codex
 
 # Install scope: "global" (default) or "project"
 # scope: project
+
+# Reusable preset definitions, typically in ~/.config/kasetto/kasetto.yaml
+# presets:
+#   - name: team-core
+#     skills:
+#       - source: https://github.com/org/shared-skills
+#         skills: "*"
+
+# Include preset definitions from this file or your global config
+# include_presets:
+#   - team-core
 
 skills:
   # Pull specific skills from a GitHub repo
@@ -260,7 +273,11 @@ mcps:
 | `agent`           | no       | One or more [supported agent presets](#supported-agents)            |
 | `destination`     | no       | Explicit install path - overrides `agent` if both are set           |
 | `scope`           | no       | `"global"` (default) or `"project"` - where to install              |
+| `presets`         | no       | Named reusable skill source groups, usually defined in the global config |
+| `include_presets` | no       | Preset names to prepend from the repo config and/or global config   |
 | `skills`          | **yes**  | List of skill sources                                               |
+| `presets[].name`  | **yes**  | Preset name referenced from `include_presets`                       |
+| `presets[].skills` | **yes** | Skill source list using the same shape as top-level `skills`        |
 | `skills[].source` | **yes**  | Git host URL or local path                                          |
 | `skills[].branch` | no       | Branch for remote sources (default: `main`, falls back to `master`) |
 | `skills[].ref`    | no       | Git tag, commit SHA, or ref (takes priority over `branch`)          |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,17 @@ agent: codex
 # Install scope: "global" (default) or "project"
 # scope: project
 
+# Reusable preset definitions, typically in ~/.config/kasetto/kasetto.yaml
+# presets:
+#   - name: team-core
+#     skills:
+#       - source: https://github.com/org/shared-skills
+#         skills: "*"
+
+# Include preset definitions from this file or your global config
+# include_presets:
+#   - team-core
+
 skills:
   # Pull specific skills from a GitHub repo
   - source: https://github.com/org/skill-pack
@@ -60,13 +71,24 @@ mcps:
 
 ### Top-Level Fields
 
-| Key           | Required | Description                                                         |
-| ------------- | -------- | ------------------------------------------------------------------- |
-| `agent`       | no       | One or more [supported agent presets](./agents.md) - string or list |
-| `destination` | no       | Explicit install path - overrides `agent` if both are set           |
-| `scope`       | no       | `"global"` (default) or `"project"` - where to install              |
-| `skills`      | **yes**  | List of skill sources                                               |
-| `mcps`        | no       | List of MCP server sources                                          |
+| Key               | Required | Description                                                         |
+| ----------------- | -------- | ------------------------------------------------------------------- |
+| `agent`           | no       | One or more [supported agent presets](./agents.md) - string or list |
+| `destination`     | no       | Explicit install path - overrides `agent` if both are set           |
+| `scope`           | no       | `"global"` (default) or `"project"` - where to install              |
+| `presets`         | no       | Named reusable skill-source groups, usually defined in the global config |
+| `include_presets` | no       | Preset names to prepend from the current config and/or global config |
+| `skills`          | **yes**  | List of skill sources                                               |
+| `mcps`            | no       | List of MCP server sources                                          |
+
+### Preset Fields
+
+Each entry in the `presets` list defines a named group of skill sources:
+
+| Key                | Required | Description                                           |
+| ------------------ | -------- | ----------------------------------------------------- |
+| `presets[].name`   | **yes**  | Preset name referenced from `include_presets`         |
+| `presets[].skills` | **yes**  | Skill source list using the same shape as top-level `skills` |
 
 ### Skill Source Fields
 
@@ -108,6 +130,44 @@ a non-standard layout.
 MCP config files must contain a `mcpServers` object with server definitions. Servers are merged
 into each agent's native settings file (e.g., `.claude.json` for Claude Code, `.cursor/mcp.json`
 for Cursor). See [how sync works](./how-sync-works.md) for merge behavior details.
+
+## Reusable Presets
+
+Presets let you define reusable skill bundles once and include them in repo-level configs.
+
+```yaml
+# ~/.config/kasetto/kasetto.yaml
+presets:
+  - name: team-core
+    skills:
+      - source: https://github.com/acme/shared-skills
+        skills:
+          - code-reviewer
+          - doc-coauthoring
+```
+
+```yaml
+# ./kasetto.yaml
+agent: claude-code
+
+include_presets:
+  - team-core
+
+skills:
+  - source: ./skills
+    skills:
+      - repo-helper
+```
+
+When Kasetto loads the repo config, it expands `include_presets` into the top-level `skills` list.
+Included preset sources are prepended ahead of the repo's own `skills` entries.
+
+A few important rules:
+
+- Presets only expand into `skills`. They do not add `mcps`.
+- Presets can be defined in the current config or in the global config at `~/.config/kasetto/kasetto.yaml`.
+- If the same preset name is defined twice across those sources, Kasetto fails with a duplicate-preset error.
+- If `include_presets` references a name that does not exist, Kasetto fails before syncing.
 
 ## Remote Configs
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -58,6 +58,36 @@ mcps:
   - source: https://github.com/acme/mcp-packs
 ```
 
+## Shared Team Presets With Repo Overrides
+
+Put reusable team defaults in the global config, then include them from each repo:
+
+```yaml
+# ~/.config/kasetto/kasetto.yaml
+presets:
+  - name: team-core
+    skills:
+      - source: https://github.com/acme/shared-skills
+        skills:
+          - code-reviewer
+          - doc-coauthoring
+```
+
+```yaml
+# ./kasetto.yaml
+agent: claude-code
+
+include_presets:
+  - team-core
+
+skills:
+  - source: ./skills
+    skills:
+      - repo-helper
+```
+
+Kasetto expands `include_presets` before the repo-local `skills` list, so teams can keep a shared baseline and still add per-repo skills.
+
 ## MCP Packs: Pinning And Rollouts
 
 Pin an MCP pack source to a git tag or commit SHA:

--- a/kasetto.example.yaml
+++ b/kasetto.example.yaml
@@ -4,6 +4,10 @@ agent: codex
 # Option B: manual destination (takes precedence if both are set)
 # destination: ./.agents/skills
 
+# Import presets from another kasetto config file
+# preset_configs:
+#   - https://github.com/acme/team-config/blob/main/kasetto.yaml
+
 skills:
   - source: https://github.com/pivoshenko/pivoshenko.ai
     skills:

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -27,6 +27,10 @@ const TEMPLATE: &str = r#"# Kasetto - https://github.com/pivoshenko/kasetto
 #       - source: https://github.com/example/skill-pack
 #         skills: "*"
 
+# Remote config files that define additional presets
+# preset_configs:
+#   - https://github.com/example/team-config/blob/main/kasetto.yaml
+
 # Include presets from this file or your global config
 # include_presets:
 #   - team-core

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -20,6 +20,17 @@ const TEMPLATE: &str = r#"# Kasetto - https://github.com/pivoshenko/kasetto
 # Or set a custom skills directory
 # destination: ~/.claude/skills
 
+# Global/shared presets you can include from repo configs
+# presets:
+#   - name: team-core
+#     skills:
+#       - source: https://github.com/example/skill-pack
+#         skills: "*"
+
+# Include presets from this file or your global config
+# include_presets:
+#   - team-core
+
 # skills:
 #   - source: https://github.com/example/skill-pack
 #     skills: "*"

--- a/src/fsops/mod.rs
+++ b/src/fsops/mod.rs
@@ -16,10 +16,11 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::{err, Result};
-use crate::model::{Config, Scope, SkillTarget, SkillsField};
+use crate::model::{Config, PresetDefinition, Scope, SkillTarget, SkillsField};
 use crate::source::{
     auth_env_inline_help, auth_for_request_url, http_fetch_auth_hint, rewrite_browse_to_raw_url,
 };
+use crate::DEFAULT_GLOBAL_CONFIG_FILENAME;
 
 pub(crate) fn load_config_any(config_path: &str) -> Result<(Config, PathBuf, String)> {
     if config_path.starts_with("http://") || config_path.starts_with("https://") {
@@ -53,21 +54,53 @@ pub(crate) fn load_config_any(config_path: &str) -> Result<(Config, PathBuf, Str
                 auth_env_inline_help(config_path)
             )));
         }
-        let cfg: Config = serde_yaml::from_str(&text)?;
+        let mut cfg: Config = serde_yaml::from_str(&text)?;
         let cfg_dir = std::env::current_dir()
             .map_err(|e| err(format!("failed to get current directory: {e}")))?;
+        expand_config_presets(&mut cfg, None)?;
         return Ok((cfg, cfg_dir, config_path.to_string()));
     }
 
     let cfg_abs = fs::canonicalize(config_path)
         .map_err(|_| err(format!("config not found: {config_path}")))?;
     let cfg_text = fs::read_to_string(&cfg_abs)?;
-    let cfg: Config = serde_yaml::from_str(&cfg_text)?;
+    let mut cfg: Config = serde_yaml::from_str(&cfg_text)?;
+    expand_config_presets(&mut cfg, Some(&cfg_abs))?;
     let cfg_dir = cfg_abs
         .parent()
         .map(Path::to_path_buf)
         .ok_or_else(|| err("invalid config path"))?;
     Ok((cfg, cfg_dir, cfg_abs.to_string_lossy().to_string()))
+}
+
+fn expand_config_presets(cfg: &mut Config, current_config_path: Option<&Path>) -> Result<()> {
+    if cfg.include_presets.is_empty() {
+        return Ok(());
+    }
+
+    let global_presets = load_global_presets(current_config_path)?;
+    cfg.expand_included_presets(&global_presets)
+}
+
+fn load_global_presets(current_config_path: Option<&Path>) -> Result<Vec<PresetDefinition>> {
+    let global_path = dirs_kasetto_config()?.join(DEFAULT_GLOBAL_CONFIG_FILENAME);
+    if !global_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let global_path = fs::canonicalize(&global_path).unwrap_or(global_path);
+    if current_config_path == Some(global_path.as_path()) {
+        return Ok(Vec::new());
+    }
+
+    let text = fs::read_to_string(&global_path)?;
+    let cfg: Config = serde_yaml::from_str(&text).map_err(|e| {
+        err(format!(
+            "failed to parse global config presets from {}: {e}",
+            global_path.display()
+        ))
+    })?;
+    Ok(cfg.presets)
 }
 
 pub(crate) type TargetSelection = (Vec<(String, PathBuf)>, Vec<BrokenSkill>);
@@ -233,6 +266,12 @@ mod tests {
     use super::*;
     use crate::model::{Agent, AgentField, Config, GitPin, SkillTarget, SkillsField};
     use std::path::Path;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn select_targets_reports_missing_skill() {
@@ -315,6 +354,68 @@ mod tests {
             Some(AgentField::Many(vec![Agent::ClaudeCode, Agent::Cursor]))
         );
         assert_eq!(multi.agents(), vec![Agent::ClaudeCode, Agent::Cursor]);
+    }
+
+    #[test]
+    fn load_config_any_expands_include_presets_from_global_config() {
+        let _guard = env_lock().lock().expect("env lock");
+        let root = temp_dir("kasetto-presets-load");
+        let home = root.join("home");
+        let xdg_config = root.join("xdg-config");
+        let global_dir = xdg_config.join("kasetto");
+        let repo_dir = root.join("repo");
+        let repo_config = repo_dir.join("kasetto.yaml");
+
+        fs::create_dir_all(&global_dir).expect("create global dir");
+        fs::create_dir_all(&repo_dir).expect("create repo dir");
+        fs::write(
+            global_dir.join("kasetto.yaml"),
+            r#"
+presets:
+  - name: team-core
+    skills:
+      - source: https://github.com/example/team
+        skills: "*"
+"#,
+        )
+        .expect("write global config");
+        fs::write(
+            &repo_config,
+            r#"
+agent: cursor
+include_presets:
+  - team-core
+skills:
+  - source: ~/repo-skills
+    skills: "*"
+"#,
+        )
+        .expect("write repo config");
+
+        let old_home = std::env::var_os("HOME");
+        let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::set_var("HOME", &home);
+        std::env::set_var("XDG_CONFIG_HOME", &xdg_config);
+
+        let (cfg, cfg_dir, cfg_label) =
+            load_config_any(&repo_config.to_string_lossy()).expect("load config with presets");
+
+        match old_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+        match old_xdg {
+            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+
+        assert_eq!(cfg_dir, repo_dir);
+        assert_eq!(cfg_label, repo_config.to_string_lossy());
+        assert_eq!(cfg.skills.len(), 2);
+        assert_eq!(cfg.skills[0].source, "https://github.com/example/team");
+        assert_eq!(cfg.skills[1].source, "~/repo-skills");
+
+        let _ = fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src/fsops/mod.rs
+++ b/src/fsops/mod.rs
@@ -19,42 +19,18 @@ use crate::error::{err, Result};
 use crate::model::{Config, PresetDefinition, Scope, SkillTarget, SkillsField};
 use crate::source::{
     auth_env_inline_help, auth_for_request_url, http_fetch_auth_hint, rewrite_browse_to_raw_url,
+    auth_env_inline_help, auth_for_request_url, http_fetch_auth_hint, normalize_remote_yaml_url,
+    normalize_remote_yaml_url, rewrite_browse_to_raw_url,
 };
 use crate::DEFAULT_GLOBAL_CONFIG_FILENAME;
 
 pub(crate) fn load_config_any(config_path: &str) -> Result<(Config, PathBuf, String)> {
     if config_path.starts_with("http://") || config_path.starts_with("https://") {
-        let fetch_url = match rewrite_browse_to_raw_url(config_path) {
-            Some(rewritten) if rewritten != config_path => {
-                eprintln!("note: rewrote browser URL to raw content: {rewritten}");
-                rewritten
-            }
-            _ => config_path.to_string(),
-        };
-        let auth = auth_for_request_url(&fetch_url);
-        let request = auth.apply(http_client()?.get(&fetch_url));
-        let response = request
-            .send()
-            .map_err(|e| err(format!("failed to fetch remote config: {config_path}: {e}")))?;
-        let status = response.status().as_u16();
-        let text = response.text().map_err(|e| {
-            err(format!(
-                "failed to read remote config body for {config_path}: {e}"
-            ))
-        })?;
-        if !(200..300).contains(&status) {
-            return Err(err(format!(
-                "remote config returned HTTP {status} for {config_path}{}",
-                http_fetch_auth_hint(config_path, status)
-            )));
+        let fetch_url = normalize_remote_yaml_url(config_path)?;
+        if fetch_url != config_path {
+            eprintln!("note: rewrote browser URL to raw content: {fetch_url}");
         }
-        if text.trim_start().starts_with("<!DOCTYPE") || text.trim_start().starts_with("<html") {
-            return Err(err(format!(
-                "remote config at {config_path} returned a login/HTML page instead of YAML - {}",
-                auth_env_inline_help(config_path)
-            )));
-        }
-        let mut cfg: Config = serde_yaml::from_str(&text)?;
+        let mut cfg = load_remote_config(config_path)?;
         let cfg_dir = std::env::current_dir()
             .map_err(|e| err(format!("failed to get current directory: {e}")))?;
         expand_config_presets(&mut cfg, None)?;
@@ -78,8 +54,13 @@ fn expand_config_presets(cfg: &mut Config, current_config_path: Option<&Path>) -
         return Ok(());
     }
 
-    let global_presets = load_global_presets(current_config_path)?;
-    cfg.expand_included_presets(&global_presets)
+    let mut available_presets = load_global_presets(current_config_path)?;
+    let mut seen_remote_configs = std::collections::HashSet::new();
+    available_presets.extend(load_remote_preset_configs(
+        &cfg.preset_configs,
+        &mut seen_remote_configs,
+    )?);
+    cfg.expand_included_presets(&available_presets)
 }
 
 fn load_global_presets(current_config_path: Option<&Path>) -> Result<Vec<PresetDefinition>> {
@@ -100,7 +81,62 @@ fn load_global_presets(current_config_path: Option<&Path>) -> Result<Vec<PresetD
             global_path.display()
         ))
     })?;
-    Ok(cfg.presets)
+    let mut seen_remote_configs = std::collections::HashSet::new();
+    collect_config_presets(&cfg, &mut seen_remote_configs)
+}
+
+fn collect_config_presets(
+    cfg: &Config,
+    seen_remote_configs: &mut std::collections::HashSet<String>,
+) -> Result<Vec<PresetDefinition>> {
+    let mut presets = load_remote_preset_configs(&cfg.preset_configs, seen_remote_configs)?;
+    presets.extend(cfg.presets.clone());
+    Ok(presets)
+}
+
+fn load_remote_preset_configs(
+    preset_configs: &[String],
+    seen_remote_configs: &mut std::collections::HashSet<String>,
+) -> Result<Vec<PresetDefinition>> {
+    let mut presets = Vec::new();
+    for preset_config in preset_configs {
+        let normalized = normalize_remote_yaml_url(preset_config)?;
+        if !seen_remote_configs.insert(normalized.clone()) {
+            continue;
+        }
+
+        let cfg = load_remote_config(&normalized)?;
+        presets.extend(collect_config_presets(&cfg, seen_remote_configs)?);
+    }
+    Ok(presets)
+}
+
+fn load_remote_config(config_url: &str) -> Result<Config> {
+    let fetch_url = normalize_remote_yaml_url(config_url)?;
+    let auth = auth_for_request_url(config_url);
+    let request = auth.apply(http_client()?.get(&fetch_url));
+    let response = request
+        .send()
+        .map_err(|e| err(format!("failed to fetch remote config: {config_url}: {e}")))?;
+    let status = response.status().as_u16();
+    let text = response.text().map_err(|e| {
+        err(format!(
+            "failed to read remote config body for {config_url}: {e}"
+        ))
+    })?;
+    if !(200..300).contains(&status) {
+        return Err(err(format!(
+            "remote config returned HTTP {status} for {config_url}{}",
+            http_fetch_auth_hint(config_url, status)
+        )));
+    }
+    if text.trim_start().starts_with("<!DOCTYPE") || text.trim_start().starts_with("<html") {
+        return Err(err(format!(
+            "remote config at {config_url} returned a login/HTML page instead of YAML - {}",
+            auth_env_inline_help(config_url)
+        )));
+    }
+    Ok(serde_yaml::from_str(&text)?)
 }
 
 pub(crate) type TargetSelection = (Vec<(String, PathBuf)>, Vec<BrokenSkill>);
@@ -265,12 +301,51 @@ pub(crate) fn temp_dir(prefix: &str) -> PathBuf {
 mod tests {
     use super::*;
     use crate::model::{Agent, AgentField, Config, GitPin, SkillTarget, SkillsField};
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
     use std::path::Path;
     use std::sync::{Mutex, OnceLock};
+    use std::thread;
 
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn serve_yaml_once(path: &'static str, body: &'static str) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let addr = listener.local_addr().expect("server addr");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept connection");
+            let mut buf = [0_u8; 2048];
+            let read = stream.read(&mut buf).expect("read request");
+            let request = String::from_utf8_lossy(&buf[..read]);
+            let request_path = request
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .expect("request path");
+
+            if request_path == path {
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/yaml\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
+                return;
+            }
+
+            let response =
+                "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            stream
+                .write_all(response.as_bytes())
+                .expect("write 404 response");
+        });
+
+        (format!("http://{addr}{path}"), handle)
     }
 
     #[test]
@@ -416,6 +491,85 @@ skills:
         assert_eq!(cfg.skills[1].source, "~/repo-skills");
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn load_config_any_expands_include_presets_from_remote_preset_config() {
+        let _guard = env_lock().lock().expect("env lock");
+        let root = temp_dir("kasetto-remote-preset-load");
+        let home = root.join("home");
+        let xdg_config = root.join("xdg-config");
+        let repo_dir = root.join("repo");
+        let repo_config = repo_dir.join("kasetto.yaml");
+        fs::create_dir_all(&repo_dir).expect("create repo dir");
+
+        let (remote_url, server) = serve_yaml_once(
+            "/presets.yaml",
+            r#"
+presets:
+  - name: team-core
+    skills:
+      - source: https://github.com/example/team
+        skills: "*"
+"#,
+        );
+
+        fs::write(
+            &repo_config,
+            format!(
+                r#"
+agent: cursor
+preset_configs:
+  - {remote_url}
+include_presets:
+  - team-core
+skills:
+  - source: ~/repo-skills
+    skills: "*"
+"#
+            ),
+        )
+        .expect("write repo config");
+
+        let old_home = std::env::var_os("HOME");
+        let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::set_var("HOME", &home);
+        std::env::set_var("XDG_CONFIG_HOME", &xdg_config);
+
+        let (cfg, cfg_dir, cfg_label) = load_config_any(&repo_config.to_string_lossy())
+            .expect("load config with remote presets");
+
+        match old_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+        match old_xdg {
+            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+
+        server.join().expect("join server");
+
+        assert_eq!(cfg_dir, repo_dir);
+        assert_eq!(cfg_label, repo_config.to_string_lossy());
+        assert_eq!(cfg.skills.len(), 2);
+        assert_eq!(cfg.skills[0].source, "https://github.com/example/team");
+        assert_eq!(cfg.skills[1].source, "~/repo-skills");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn config_parses_preset_configs() {
+        let cfg: Config = serde_yaml::from_str(
+            "preset_configs:\n  - https://github.com/acme/team/blob/main/kasetto.yaml\nskills: []\n",
+        )
+        .expect("parse config");
+
+        assert_eq!(
+            cfg.preset_configs,
+            vec!["https://github.com/acme/team/blob/main/kasetto.yaml"]
+        );
     }
 
     #[test]

--- a/src/fsops/mod.rs
+++ b/src/fsops/mod.rs
@@ -18,9 +18,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::error::{err, Result};
 use crate::model::{Config, PresetDefinition, Scope, SkillTarget, SkillsField};
 use crate::source::{
-    auth_env_inline_help, auth_for_request_url, http_fetch_auth_hint, rewrite_browse_to_raw_url,
     auth_env_inline_help, auth_for_request_url, http_fetch_auth_hint, normalize_remote_yaml_url,
-    normalize_remote_yaml_url, rewrite_browse_to_raw_url,
 };
 use crate::DEFAULT_GLOBAL_CONFIG_FILENAME;
 

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -1,4 +1,8 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
+
+use crate::error::{err, Result};
 
 use super::{Agent, AgentField};
 
@@ -19,6 +23,10 @@ pub(crate) struct Config {
     #[serde(default)]
     pub agent: Option<AgentField>,
     #[serde(default)]
+    pub presets: Vec<PresetDefinition>,
+    #[serde(default)]
+    pub include_presets: Vec<String>,
+    #[serde(default)]
     pub skills: Vec<SourceSpec>,
     #[serde(default)]
     pub mcps: Vec<McpSourceSpec>,
@@ -36,6 +44,48 @@ impl Config {
     pub(crate) fn resolved_scope(&self) -> Scope {
         self.scope.unwrap_or_default()
     }
+
+    pub(crate) fn expand_included_presets(
+        &mut self,
+        global_presets: &[PresetDefinition],
+    ) -> Result<()> {
+        if self.include_presets.is_empty() {
+            return Ok(());
+        }
+
+        let mut available = preset_map(global_presets)?;
+        for preset in &self.presets {
+            if available.insert(preset.name.clone(), preset).is_some() {
+                return Err(err(format!("duplicate preset definition: {}", preset.name)));
+            }
+        }
+
+        let mut expanded = Vec::new();
+        for preset_name in &self.include_presets {
+            let preset = available.get(preset_name).ok_or_else(|| {
+                err(format!(
+                    "preset not found: {preset_name} (define it in the repo config or global config)"
+                ))
+            })?;
+            expanded.extend(preset.skills.clone());
+        }
+
+        expanded.extend(std::mem::take(&mut self.skills));
+        self.skills = expanded;
+        Ok(())
+    }
+}
+
+fn preset_map<'a>(
+    presets: &'a [PresetDefinition],
+) -> Result<HashMap<String, &'a PresetDefinition>> {
+    let mut available = HashMap::new();
+    for preset in presets {
+        if available.insert(preset.name.clone(), preset).is_some() {
+            return Err(err(format!("duplicate preset definition: {}", preset.name)));
+        }
+    }
+    Ok(available)
 }
 
 /// Resolve the effective scope: CLI override > config YAML `scope:` field > Global default.
@@ -60,16 +110,57 @@ pub(crate) fn resolve_scope(cli_override: Option<Scope>, cfg: Option<&Config>) -
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_scope, Scope};
+    use super::{resolve_scope, Config, Scope};
 
     #[test]
     fn resolve_scope_prefers_cli_override() {
         assert_eq!(resolve_scope(Some(Scope::Project), None), Scope::Project);
         assert_eq!(resolve_scope(Some(Scope::Global), None), Scope::Global);
     }
+
+    #[test]
+    fn expand_included_presets_prepends_preset_skills() {
+        let global_yaml = r#"
+presets:
+  - name: team-core
+    skills:
+      - source: https://github.com/example/team
+        skills: "*"
+"#;
+        let local_yaml = r#"
+include_presets:
+  - team-core
+skills:
+  - source: ~/repo-skills
+    skills: "*"
+"#;
+
+        let global: Config = serde_yaml::from_str(global_yaml).expect("parse global config");
+        let mut local: Config = serde_yaml::from_str(local_yaml).expect("parse local config");
+
+        local
+            .expand_included_presets(&global.presets)
+            .expect("expand presets");
+
+        assert_eq!(local.skills.len(), 2);
+        assert_eq!(local.skills[0].source, "https://github.com/example/team");
+        assert_eq!(local.skills[1].source, "~/repo-skills");
+    }
+
+    #[test]
+    fn expand_included_presets_errors_for_missing_preset() {
+        let mut cfg: Config = serde_yaml::from_str("include_presets:\n  - missing\nskills: []\n")
+            .expect("parse config");
+
+        let err = cfg
+            .expand_included_presets(&[])
+            .expect_err("missing preset should fail");
+
+        assert!(err.to_string().contains("preset not found: missing"));
+    }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub(crate) struct SourceSpec {
     pub source: String,
     pub branch: Option<String>,
@@ -82,6 +173,12 @@ pub(crate) struct SourceSpec {
     #[serde(default, rename = "sub-dir", alias = "sub_dir")]
     pub sub_dir: Option<String>,
     pub skills: SkillsField,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct PresetDefinition {
+    pub name: String,
+    pub skills: Vec<SourceSpec>,
 }
 
 /// What the user specified to identify a version of the source.
@@ -107,7 +204,7 @@ impl SourceSpec {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub(crate) struct McpSourceSpec {
     pub source: String,
     pub branch: Option<String>,
@@ -130,14 +227,14 @@ impl McpSourceSpec {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(untagged)]
 pub(crate) enum SkillsField {
     Wildcard(String),
     List(Vec<SkillTarget>),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(untagged)]
 pub(crate) enum SkillTarget {
     Name(String),

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -25,6 +25,8 @@ pub(crate) struct Config {
     #[serde(default)]
     pub presets: Vec<PresetDefinition>,
     #[serde(default)]
+    pub preset_configs: Vec<String>,
+    #[serde(default)]
     pub include_presets: Vec<String>,
     #[serde(default)]
     pub skills: Vec<SourceSpec>,
@@ -76,9 +78,7 @@ impl Config {
     }
 }
 
-fn preset_map<'a>(
-    presets: &'a [PresetDefinition],
-) -> Result<HashMap<String, &'a PresetDefinition>> {
+fn preset_map(presets: &[PresetDefinition]) -> Result<HashMap<String, &PresetDefinition>> {
     let mut available = HashMap::new();
     for preset in presets {
         if available.insert(preset.name.clone(), preset).is_some() {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 pub(crate) use agent::{all_mcp_project_targets, all_mcp_settings_targets, Agent, AgentField};
 pub(crate) use config::{
-    resolve_scope, Config, GitPin, Scope, SkillTarget, SkillsField, SourceSpec,
+    resolve_scope, Config, GitPin, PresetDefinition, Scope, SkillTarget, SkillsField, SourceSpec,
 };
 pub(crate) use types::{Action, InstalledSkill, Report, SkillEntry, State, Summary, SyncFailure};
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -6,7 +6,6 @@ mod parse;
 mod remote;
 
 pub(crate) use auth::{auth_env_inline_help, auth_for_request_url, http_fetch_auth_hint};
-pub(crate) use remote::rewrite_browse_to_raw_url;
 pub(crate) use remote::normalize_remote_yaml_url;
 
 use std::collections::HashMap;

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -7,6 +7,7 @@ mod remote;
 
 pub(crate) use auth::{auth_env_inline_help, auth_for_request_url, http_fetch_auth_hint};
 pub(crate) use remote::rewrite_browse_to_raw_url;
+pub(crate) use remote::normalize_remote_yaml_url;
 
 use std::collections::HashMap;
 use std::fs;

--- a/src/source/remote.rs
+++ b/src/source/remote.rs
@@ -166,15 +166,6 @@ pub(crate) fn rewrite_browse_to_raw_url(url: &str) -> Option<String> {
     rewrite_gitlab_raw_path(host, rest)
 }
 
-pub(crate) fn rewrite_gitlab_raw_url(url: &str) -> Option<String> {
-    let cleaned = url.split('?').next().unwrap_or(url);
-    let without_scheme = cleaned
-        .strip_prefix("https://")
-        .or_else(|| cleaned.strip_prefix("http://"))?;
-    let (host, rest) = without_scheme.split_once('/')?;
-    rewrite_gitlab_raw_path(host, rest)
-}
-
 fn rewrite_github_blob(rest: &str) -> Option<String> {
     let parts: Vec<&str> = rest.splitn(5, '/').collect();
     if parts.len() < 5 {

--- a/src/source/remote.rs
+++ b/src/source/remote.rs
@@ -81,6 +81,55 @@ fn gitea_archive_tarball_url(host: &str, owner: &str, repo: &str, branch: &str) 
     format!("https://{host}/{owner}/{repo}/archive/{branch}.tar.gz")
 }
 
+pub(crate) fn normalize_remote_yaml_url(url: &str) -> Result<String> {
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|e| err(format!("invalid remote config URL: {url}: {e}")))?;
+
+    match parsed.scheme() {
+        "http" | "https" => {}
+        scheme => {
+            return Err(err(format!(
+                "remote config URL must use http or https: {url} (got {scheme})"
+            )));
+        }
+    }
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| err(format!("remote config URL is missing a host: {url}")))?;
+    if !has_yaml_extension(parsed.path()) {
+        return Err(err(format!(
+            "remote config URL must point to a .yml or .yaml file: {url}"
+        )));
+    }
+
+    if matches!(
+        host,
+        "raw.githubusercontent.com" | "www.raw.githubusercontent.com"
+    ) {
+        return Ok(parsed.to_string());
+    }
+
+    if let Some(rewritten) = rewrite_browse_to_raw_url(url) {
+        return Ok(rewritten);
+    }
+
+    if matches!(host, "github.com" | "www.github.com") {
+        return Err(err(format!(
+            "GitHub remote config URLs must use /blob/, /raw/, or raw.githubusercontent.com and point to a .yml or .yaml file: {url}"
+        )));
+    }
+
+    Ok(parsed.to_string())
+}
+
+fn has_yaml_extension(path: &str) -> bool {
+    path.rsplit('/').next().is_some_and(|name| {
+        let lower = name.to_ascii_lowercase();
+        lower.ends_with(".yml") || lower.ends_with(".yaml")
+    })
+}
+
 /// Rewrite browser-style URLs (e.g. `/blob/`, `/src/branch/`) to the raw-content
 /// equivalent so users can paste a URL straight from their browser into
 /// `--config` or skill sources.
@@ -100,7 +149,7 @@ pub(crate) fn rewrite_browse_to_raw_url(url: &str) -> Option<String> {
     let without_scheme = &cleaned[scheme_len..];
     let (host, rest) = without_scheme.split_once('/')?;
 
-    if host == "github.com" {
+    if matches!(host, "github.com" | "www.github.com") {
         if let Some(rewritten) = rewrite_github_blob(rest) {
             return Some(rewritten);
         }
@@ -114,7 +163,16 @@ pub(crate) fn rewrite_browse_to_raw_url(url: &str) -> Option<String> {
         return None;
     }
 
-    rewrite_gitlab_raw_url(host, rest)
+    rewrite_gitlab_raw_path(host, rest)
+}
+
+pub(crate) fn rewrite_gitlab_raw_url(url: &str) -> Option<String> {
+    let cleaned = url.split('?').next().unwrap_or(url);
+    let without_scheme = cleaned
+        .strip_prefix("https://")
+        .or_else(|| cleaned.strip_prefix("http://"))?;
+    let (host, rest) = without_scheme.split_once('/')?;
+    rewrite_gitlab_raw_path(host, rest)
 }
 
 fn rewrite_github_blob(rest: &str) -> Option<String> {
@@ -159,7 +217,7 @@ fn rewrite_gitea_src(scheme: &str, host: &str, rest: &str, query: Option<&str>) 
     Some(out)
 }
 
-fn rewrite_gitlab_raw_url(host: &str, rest: &str) -> Option<String> {
+fn rewrite_gitlab_raw_path(host: &str, rest: &str) -> Option<String> {
     for marker in ["/-/raw/", "/-/blob/"] {
         if let Some(idx) = rest.find(marker) {
             let project = &rest[..idx];
@@ -366,5 +424,57 @@ mod tests {
     #[test]
     fn rewrite_skips_non_http_scheme() {
         assert!(rewrite_browse_to_raw_url("git@github.com:owner/repo.git").is_none());
+    }
+
+    #[test]
+    fn normalize_remote_yaml_url_rewrites_github_blob() {
+        let url = normalize_remote_yaml_url(
+            "https://github.com/acme/team/blob/main/config/kasetto.yaml?raw=1",
+        )
+        .expect("normalize");
+        assert_eq!(
+            url,
+            "https://raw.githubusercontent.com/acme/team/main/config/kasetto.yaml"
+        );
+    }
+
+    #[test]
+    fn normalize_remote_yaml_url_accepts_raw_github() {
+        let url = normalize_remote_yaml_url(
+            "https://raw.githubusercontent.com/acme/team/main/config/kasetto.yml",
+        )
+        .expect("normalize");
+        assert_eq!(
+            url,
+            "https://raw.githubusercontent.com/acme/team/main/config/kasetto.yml"
+        );
+    }
+
+    #[test]
+    fn normalize_remote_yaml_url_rejects_non_yaml_paths() {
+        let err = normalize_remote_yaml_url("https://example.com/config.json").expect_err("reject");
+        assert!(err.to_string().contains(".yml or .yaml"));
+    }
+
+    #[test]
+    fn normalize_remote_yaml_url_rejects_non_blob_github_urls() {
+        let err =
+            normalize_remote_yaml_url("https://github.com/acme/team/tree/main/config/kasetto.yaml")
+                .expect_err("reject");
+        assert!(err
+            .to_string()
+            .contains("must use /blob/, /raw/, or raw.githubusercontent.com"));
+    }
+
+    #[test]
+    fn normalize_remote_yaml_url_rewrites_gitlab_blob() {
+        let url = normalize_remote_yaml_url(
+            "https://gitlab.example.com/group/repo/-/blob/main/kasetto.yaml",
+        )
+        .expect("normalize");
+        assert_eq!(
+            url,
+            "https://gitlab.example.com/api/v4/projects/group%2Frepo/repository/files/kasetto.yaml/raw?ref=main"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add `presets` and `include_presets` config support so repo configs can expand shared skill bundles from local or global config
- validate preset expansion for duplicate and missing preset names, and cover global preset loading with targeted tests
- document the preset workflow in the README, config reference, cookbook, and generated init template

## Testing
- cargo test presets