### PR TITLE
feat(cli): Add config source management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,37 @@ kst sync [--config <path-or-url>] [--dry-run] [--quiet] [--json] [--plain] [--ve
 
 Missing skills are reported as broken but won't stop the rest of the run. The exit code is non-zero only for source-level failures.
 
+### `kst add`
+
+Discovers skills from a repo or local source and writes that source into config. By default it writes `./kasetto.yaml`, creating it when missing. With `--global`, it writes `$XDG_CONFIG_HOME/kasetto/kasetto.yaml`.
+
+```bash
+kst add <repo> [--skill <name>]... [--global]
+```
+
+| Flag        | What it does                                                         |
+| ----------- | -------------------------------------------------------------------- |
+| `--skill`   | Add only specific skills; repeat to include multiple names           |
+| `--global`  | Write the global config instead of `./kasetto.yaml`                  |
+
+If the source is already present, Kasetto updates it instead of duplicating it. Re-adding a source with no `--skill` promotes it to `skills: "*"`. Remote repo sources are normalized to a standard canonical URL before being written.
+
+### `kst remove`
+
+Removes a source from config, or removes specific skills from an explicitly listed source.
+
+```bash
+kst remove <repo> [--skill <name>]... [--global] [-u]
+```
+
+| Flag        | What it does                                                         |
+| ----------- | -------------------------------------------------------------------- |
+| `--skill`   | Remove only specific skills from an explicit list                    |
+| `--global`  | Write the global config instead of `./kasetto.yaml`                  |
+| `-u`        | Skip the confirmation prompt and apply the change immediately        |
+
+By default, `kst remove` shows a preview of the config path, normalized source, requested change, and resulting state before asking `Proceed? [y/N]`. Without `--skill`, the whole source entry is removed. Selective removal from a source stored as `skills: "*"` is rejected because the config does not track an explicit stored list to subtract from.
+
 ### `kst list`
 
 Shows skills and MCP servers from the lock file(s). **Without** `--project` or `--global`, both scopes are merged so you can tell global and project installs apart (scope is shown per row / in JSON).
@@ -210,6 +241,8 @@ When `--config` is omitted, Kasetto looks for config in this order:
 
 Point it at a specific file or URL with `--config`, or run `kst init` for local `./kasetto.yaml` (`kst init --global` writes the global config file).
 To persist a remote URL as your default, add a `source:` key to `~/.config/kasetto/config.yaml`.
+
+For building a local config incrementally, use `kst add https://github.com/org/skills` to append a discovered source without hand-editing YAML. Both `kst add` and `kst remove` are available from the TUI home screen.
 
 ```yaml
 # Choose an agent preset (single or multiple)...

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,6 +26,13 @@ pub fn run() -> Result<()> {
                     show_banner: true,
                 })
             }
+            Commands::Add { add } => crate::commands::add::run(&add.repo, &add.skills, add.global),
+            Commands::Remove { remove } => crate::commands::remove::run(
+                &remove.repo,
+                &remove.skills,
+                remove.global,
+                remove.unattended,
+            ),
             Commands::List {
                 json,
                 output,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,8 @@ use crate::model::Scope;
     after_help = crate::cli_examples!(
         "kasetto",
         "kasetto sync --config https://example.com/kasetto.yaml --verbose",
+        "kasetto add https://github.com/org/skills --skill code-reviewer",
+        "kasetto remove https://github.com/org/skills --skill code-reviewer -u",
         "kasetto init",
         "kasetto list",
         "kasetto doctor",
@@ -89,6 +91,33 @@ pub(crate) struct SyncArgs {
     pub scope: ScopeArgs,
 }
 
+#[derive(Args, Clone, Debug, Default)]
+pub(crate) struct AddArgs {
+    #[arg(help = "repository URL or local path")]
+    pub repo: String,
+    #[arg(long = "skill")]
+    #[arg(help = "select one skill by name (repeatable)")]
+    pub skills: Vec<String>,
+    #[arg(long)]
+    #[arg(help = "write to $XDG_CONFIG_HOME/kasetto/kasetto.yaml")]
+    pub global: bool,
+}
+
+#[derive(Args, Clone, Debug, Default)]
+pub(crate) struct RemoveArgs {
+    #[arg(help = "repository URL or local path")]
+    pub repo: String,
+    #[arg(long = "skill")]
+    #[arg(help = "remove one skill by name (repeatable)")]
+    pub skills: Vec<String>,
+    #[arg(long)]
+    #[arg(help = "write to $XDG_CONFIG_HOME/kasetto/kasetto.yaml")]
+    pub global: bool,
+    #[arg(short = 'u')]
+    #[arg(help = "skip confirmation prompt")]
+    pub unattended: bool,
+}
+
 #[derive(Subcommand)]
 pub(crate) enum Commands {
     #[command(
@@ -120,6 +149,32 @@ pub(crate) enum Commands {
     Sync {
         #[command(flatten)]
         sync: SyncArgs,
+    },
+    #[command(
+        about = "Add a skill source to config",
+        long_about = "Discover skills from a repo or local source, then add or update that source in kasetto config. By default, writes ./kasetto.yaml and creates it if missing. With --global, writes $XDG_CONFIG_HOME/kasetto/kasetto.yaml.",
+        after_help = crate::cli_examples!(
+            "kasetto add https://github.com/org/skills",
+            "kasetto add https://github.com/org/skills --skill code-reviewer --skill docs",
+            "kasetto add https://github.com/org/skills --global",
+        )
+    )]
+    Add {
+        #[command(flatten)]
+        add: AddArgs,
+    },
+    #[command(
+        about = "Remove a skill source from config",
+        long_about = "Remove a source or selected skills from kasetto config. By default, writes ./kasetto.yaml. With --global, writes $XDG_CONFIG_HOME/kasetto/kasetto.yaml. Shows a preview before applying changes unless -u is set.",
+        after_help = crate::cli_examples!(
+            "kasetto remove https://github.com/org/skills",
+            "kasetto remove https://github.com/org/skills --skill code-reviewer --skill docs",
+            "kasetto remove https://github.com/org/skills -u --global",
+        )
+    )]
+    Remove {
+        #[command(flatten)]
+        remove: RemoveArgs,
     },
     #[command(
         about = "List installed skills and MCPs",

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -108,6 +108,7 @@ pub(crate) fn discover_available_skills(source: &str) -> Result<Vec<String>> {
         source: source.to_string(),
         branch: None,
         git_ref: None,
+        sub_dir: None,
         skills: SkillsField::Wildcard("*".to_string()),
     };
     let stage = std::env::temp_dir().join(format!(
@@ -189,6 +190,7 @@ fn upsert_skill_source(
         source: source.to_string(),
         branch: None,
         git_ref: None,
+        sub_dir: None,
         skills: if use_wildcard {
             SkillsField::Wildcard("*".to_string())
         } else {
@@ -267,16 +269,14 @@ mod tests {
 
     #[test]
     fn normalize_source_expands_github_shorthand() {
-        let dir = temp_dir("kasetto-add-github-shorthand");
-        fs::create_dir_all(&dir).expect("mkdir");
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let shorthand = format!("org/repo-{suffix}");
 
-        let original = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(&dir).expect("chdir");
-        let normalized = normalize_source("org/repo").expect("norm");
-        std::env::set_current_dir(original).expect("restore cwd");
-
-        assert_eq!(normalized, "https://github.com/org/repo");
-        let _ = fs::remove_dir_all(&dir);
+        let normalized = normalize_source(&shorthand).expect("norm");
+        assert_eq!(normalized, format!("https://github.com/{shorthand}"));
     }
 
     #[test]
@@ -286,12 +286,10 @@ mod tests {
         let nested = local.join("repo");
         fs::create_dir_all(&nested).expect("mkdirs");
 
-        let original = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(&dir).expect("chdir");
-        let normalized = normalize_source("org/repo").expect("norm");
-        std::env::set_current_dir(original).expect("restore cwd");
+        let source = nested.to_string_lossy().to_string();
+        let normalized = normalize_source(&source).expect("norm");
 
-        assert_eq!(normalized, "org/repo");
+        assert_eq!(normalized, source);
         let _ = fs::remove_dir_all(&dir);
     }
 
@@ -325,6 +323,7 @@ mod tests {
                 source: "https://github.com/org/repo".into(),
                 branch: None,
                 git_ref: None,
+                sub_dir: None,
                 skills: SkillsField::List(vec![SkillTarget::Name("alpha".into())]),
             }],
             ..Config::default()
@@ -348,6 +347,7 @@ mod tests {
                 source: "https://github.com/org/repo".into(),
                 branch: None,
                 git_ref: None,
+                sub_dir: None,
                 skills: SkillsField::List(vec![SkillTarget::Name("alpha".into())]),
             }],
             ..Config::default()
@@ -368,6 +368,7 @@ mod tests {
                 source: "https://github.com/org/repo".into(),
                 branch: None,
                 git_ref: None,
+                sub_dir: None,
                 skills: SkillsField::Wildcard("*".into()),
             }],
             ..Config::default()
@@ -405,6 +406,7 @@ mod tests {
                 source: "http://github.com/org/repo.git/".into(),
                 branch: None,
                 git_ref: None,
+                sub_dir: None,
                 skills: SkillsField::List(vec![SkillTarget::Name("alpha".into())]),
             }],
             ..Config::default()

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,0 +1,425 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::banner::print_banner;
+use crate::colors::{ACCENT, RESET, SUCCESS};
+use crate::error::{err, Result};
+use crate::fsops::dirs_kasetto_config;
+use crate::model::{Config, SkillTarget, SkillsField, SourceSpec};
+use crate::source::{materialize_source, normalize_repo_url};
+use crate::ui::SYM_OK;
+use crate::DEFAULT_CONFIG_FILENAME;
+
+pub(crate) fn run(repo: &str, skill_names: &[String], global: bool) -> Result<()> {
+    print_banner();
+    println!();
+
+    let config_path = config_path_for_edit(global)?;
+    let repo = normalize_source(repo)?;
+    let requested_skills = validate_and_collect_skills(&repo, skill_names)?;
+    let mut cfg = load_or_default_config(&config_path)?;
+
+    let summary = upsert_skill_source(&mut cfg, &repo, requested_skills, skill_names.is_empty());
+    save_config(&config_path, &cfg)?;
+
+    println!(
+        "{SUCCESS}{SYM_OK}{RESET} Updated {ACCENT}{}{RESET}",
+        config_path.display()
+    );
+    println!("  {}", summary);
+    Ok(())
+}
+
+pub(crate) fn config_path_for_edit(global: bool) -> Result<PathBuf> {
+    if global {
+        return Ok(dirs_kasetto_config()?.join(DEFAULT_CONFIG_FILENAME));
+    }
+    Ok(PathBuf::from(DEFAULT_CONFIG_FILENAME))
+}
+
+pub(crate) fn normalize_source(source: &str) -> Result<String> {
+    let trimmed = source.trim();
+    if trimmed.is_empty() {
+        return Err(err("repo must not be empty"));
+    }
+    if trimmed.contains("://") {
+        return normalize_repo_url(trimmed);
+    }
+    if let Some(expanded) = expand_github_shorthand(trimmed) {
+        if !Path::new(trimmed).exists() {
+            return Ok(expanded);
+        }
+    }
+    Ok(trimmed.to_string())
+}
+
+fn expand_github_shorthand(source: &str) -> Option<String> {
+    if source.starts_with('.')
+        || source.starts_with('/')
+        || source.starts_with('~')
+        || source.contains('\\')
+    {
+        return None;
+    }
+
+    let segments = source.split('/').collect::<Vec<_>>();
+    if segments.len() != 2 || segments.iter().any(|segment| segment.is_empty()) {
+        return None;
+    }
+
+    if !segments.iter().all(|segment| {
+        segment
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
+    }) {
+        return None;
+    }
+
+    normalize_repo_url(&format!("https://github.com/{source}")).ok()
+}
+
+fn validate_and_collect_skills(source: &str, skill_names: &[String]) -> Result<Vec<String>> {
+    let available = discover_available_skills(source)?;
+
+    if skill_names.is_empty() {
+        if available.is_empty() {
+            return Err(err(format!("no skills found in source: {source}")));
+        }
+        return Ok(Vec::new());
+    }
+
+    let mut requested = BTreeSet::new();
+    for skill in skill_names {
+        if !available
+            .iter()
+            .any(|available_skill| available_skill == skill)
+        {
+            return Err(err(format!("skill not found in source {source}: {skill}")));
+        }
+        requested.insert(skill.clone());
+    }
+
+    Ok(requested.into_iter().collect())
+}
+
+pub(crate) fn discover_available_skills(source: &str) -> Result<Vec<String>> {
+    let src = SourceSpec {
+        source: source.to_string(),
+        branch: None,
+        git_ref: None,
+        skills: SkillsField::Wildcard("*".to_string()),
+    };
+    let stage = std::env::temp_dir().join(format!(
+        "kasetto-add-{}-{}",
+        std::process::id(),
+        crate::fsops::now_unix()
+    ));
+    let materialized = materialize_source(&src, Path::new("."), &stage)?;
+    let mut available = materialized.available.keys().cloned().collect::<Vec<_>>();
+    available.sort();
+
+    if let Some(cleanup_dir) = materialized.cleanup_dir {
+        let _ = fs::remove_dir_all(cleanup_dir);
+    }
+
+    Ok(available)
+}
+
+pub(crate) fn load_or_default_config(path: &Path) -> Result<Config> {
+    if !path.exists() {
+        return Ok(Config::default());
+    }
+    let text = fs::read_to_string(path)?;
+    Ok(serde_yaml::from_str(&text)?)
+}
+
+pub(crate) fn save_config(path: &Path, cfg: &Config) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+
+    let yaml = serde_yaml::to_string(cfg)?;
+    fs::write(path, yaml)?;
+    Ok(())
+}
+
+fn upsert_skill_source(
+    cfg: &mut Config,
+    source: &str,
+    requested_skills: Vec<String>,
+    use_wildcard: bool,
+) -> String {
+    if let Some(existing) = cfg
+        .skills
+        .iter_mut()
+        .find(|entry| source_matches(&entry.source, source))
+    {
+        existing.source = source.to_string();
+        if use_wildcard {
+            existing.skills = SkillsField::Wildcard("*".to_string());
+            return format!("set {source} to sync all skills");
+        }
+
+        if matches!(existing.skills, SkillsField::Wildcard(ref wildcard) if wildcard == "*") {
+            return format!("kept {source} syncing all skills");
+        }
+
+        let mut merged = skill_names_from_field(&existing.skills);
+        let before = merged.len();
+        merged.extend(requested_skills);
+        existing.skills = SkillsField::List(merged.into_iter().map(SkillTarget::Name).collect());
+
+        let added = skill_names_from_field(&existing.skills)
+            .len()
+            .saturating_sub(before);
+        return if added == 0 {
+            format!("no changes for {source}; requested skills were already present")
+        } else {
+            format!(
+                "added {added} skill{} to existing source {source}",
+                pluralize(added)
+            )
+        };
+    }
+
+    cfg.skills.push(SourceSpec {
+        source: source.to_string(),
+        branch: None,
+        git_ref: None,
+        skills: if use_wildcard {
+            SkillsField::Wildcard("*".to_string())
+        } else {
+            SkillsField::List(
+                requested_skills
+                    .into_iter()
+                    .map(SkillTarget::Name)
+                    .collect(),
+            )
+        },
+    });
+
+    if use_wildcard {
+        format!("added new source {source} with all discovered skills")
+    } else {
+        let count = match cfg.skills.last() {
+            Some(SourceSpec {
+                skills: SkillsField::List(items),
+                ..
+            }) => items.len(),
+            _ => 0,
+        };
+        format!(
+            "added new source {source} with {count} selected skill{}",
+            pluralize(count)
+        )
+    }
+}
+
+pub(crate) fn skill_names_from_field(skills: &SkillsField) -> BTreeSet<String> {
+    match skills {
+        SkillsField::Wildcard(_) => BTreeSet::new(),
+        SkillsField::List(items) => items
+            .iter()
+            .map(|item| match item {
+                SkillTarget::Name(name) => name.clone(),
+                SkillTarget::Obj { name, .. } => name.clone(),
+            })
+            .collect(),
+    }
+}
+
+fn pluralize(count: usize) -> &'static str {
+    if count == 1 {
+        ""
+    } else {
+        "s"
+    }
+}
+
+pub(crate) fn source_matches(existing: &str, target: &str) -> bool {
+    normalize_source(existing)
+        .map(|normalized| normalized == target)
+        .unwrap_or_else(|_| existing.trim() == target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::SkillsField;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{}-{nonce}", std::process::id()))
+    }
+
+    #[test]
+    fn normalize_source_standardizes_repo_urls() {
+        let normalized = normalize_source(" http://github.com/org/repo.git/ ").expect("norm");
+        assert_eq!(normalized, "https://github.com/org/repo");
+    }
+
+    #[test]
+    fn normalize_source_expands_github_shorthand() {
+        let dir = temp_dir("kasetto-add-github-shorthand");
+        fs::create_dir_all(&dir).expect("mkdir");
+
+        let original = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(&dir).expect("chdir");
+        let normalized = normalize_source("org/repo").expect("norm");
+        std::env::set_current_dir(original).expect("restore cwd");
+
+        assert_eq!(normalized, "https://github.com/org/repo");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn normalize_source_keeps_existing_local_path() {
+        let dir = temp_dir("kasetto-add-local-source");
+        let local = dir.join("org");
+        let nested = local.join("repo");
+        fs::create_dir_all(&nested).expect("mkdirs");
+
+        let original = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(&dir).expect("chdir");
+        let normalized = normalize_source("org/repo").expect("norm");
+        std::env::set_current_dir(original).expect("restore cwd");
+
+        assert_eq!(normalized, "org/repo");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_or_default_config_returns_empty_when_missing() {
+        let path = temp_dir("kasetto-add-missing").join("kasetto.yaml");
+        let cfg = load_or_default_config(&path).expect("config");
+        assert!(cfg.skills.is_empty());
+    }
+
+    #[test]
+    fn upsert_skill_source_appends_new_source() {
+        let mut cfg = Config::default();
+
+        let summary = upsert_skill_source(
+            &mut cfg,
+            "https://github.com/org/repo",
+            vec!["alpha".into(), "beta".into()],
+            false,
+        );
+
+        assert!(summary.contains("added new source"));
+        assert_eq!(cfg.skills.len(), 1);
+        assert!(matches!(&cfg.skills[0].skills, SkillsField::List(items) if items.len() == 2));
+    }
+
+    #[test]
+    fn upsert_skill_source_merges_without_duplicates() {
+        let mut cfg = Config {
+            skills: vec![SourceSpec {
+                source: "https://github.com/org/repo".into(),
+                branch: None,
+                git_ref: None,
+                skills: SkillsField::List(vec![SkillTarget::Name("alpha".into())]),
+            }],
+            ..Config::default()
+        };
+
+        let summary = upsert_skill_source(
+            &mut cfg,
+            "https://github.com/org/repo",
+            vec!["beta".into(), "alpha".into()],
+            false,
+        );
+
+        assert!(summary.contains("added 1 skill"));
+        assert!(matches!(&cfg.skills[0].skills, SkillsField::List(items) if items.len() == 2));
+    }
+
+    #[test]
+    fn upsert_skill_source_promotes_existing_source_to_wildcard() {
+        let mut cfg = Config {
+            skills: vec![SourceSpec {
+                source: "https://github.com/org/repo".into(),
+                branch: None,
+                git_ref: None,
+                skills: SkillsField::List(vec![SkillTarget::Name("alpha".into())]),
+            }],
+            ..Config::default()
+        };
+
+        let summary = upsert_skill_source(&mut cfg, "https://github.com/org/repo", vec![], true);
+
+        assert!(summary.contains("sync all skills"));
+        assert!(
+            matches!(cfg.skills[0].skills, SkillsField::Wildcard(ref wildcard) if wildcard == "*")
+        );
+    }
+
+    #[test]
+    fn upsert_skill_source_keeps_existing_wildcard() {
+        let mut cfg = Config {
+            skills: vec![SourceSpec {
+                source: "https://github.com/org/repo".into(),
+                branch: None,
+                git_ref: None,
+                skills: SkillsField::Wildcard("*".into()),
+            }],
+            ..Config::default()
+        };
+
+        let summary = upsert_skill_source(
+            &mut cfg,
+            "https://github.com/org/repo",
+            vec!["alpha".into()],
+            false,
+        );
+
+        assert!(summary.contains("syncing all skills"));
+        assert!(
+            matches!(cfg.skills[0].skills, SkillsField::Wildcard(ref wildcard) if wildcard == "*")
+        );
+    }
+
+    #[test]
+    fn save_config_creates_parent_directories() {
+        let dir = temp_dir("kasetto-add-save");
+        let path = dir.join("nested").join("kasetto.yaml");
+        let cfg = Config::default();
+
+        save_config(&path, &cfg).expect("save");
+
+        assert!(path.exists());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn upsert_skill_source_matches_existing_unnormalized_repo_url() {
+        let mut cfg = Config {
+            skills: vec![SourceSpec {
+                source: "http://github.com/org/repo.git/".into(),
+                branch: None,
+                git_ref: None,
+                skills: SkillsField::List(vec![SkillTarget::Name("alpha".into())]),
+            }],
+            ..Config::default()
+        };
+
+        let summary = upsert_skill_source(
+            &mut cfg,
+            "https://github.com/org/repo",
+            vec!["beta".into()],
+            false,
+        );
+
+        assert!(summary.contains("existing source"));
+        assert_eq!(cfg.skills.len(), 1);
+        assert_eq!(cfg.skills[0].source, "https://github.com/org/repo");
+        assert!(matches!(&cfg.skills[0].skills, SkillsField::List(items) if items.len() == 2));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,8 +1,10 @@
+pub(crate) mod add;
 pub(crate) mod clean;
 pub(crate) mod completions;
 pub(crate) mod doctor;
 pub(crate) mod init;
 pub(crate) mod list;
+pub(crate) mod remove;
 pub(crate) mod self_update;
 pub(crate) mod sync;
 pub(crate) mod uninstall;

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -214,6 +214,7 @@ mod tests {
                 source: source.into(),
                 branch: None,
                 git_ref: None,
+                sub_dir: None,
                 skills,
             }],
             ..Config::default()

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -1,0 +1,336 @@
+use std::collections::BTreeSet;
+use std::io::{self, IsTerminal, Write};
+
+use crate::banner::print_banner;
+use crate::colors::{ACCENT, RESET, SUCCESS, WARNING};
+use crate::commands::add::{
+    config_path_for_edit, load_or_default_config, normalize_source, save_config,
+    skill_names_from_field, source_matches,
+};
+use crate::error::{err, Result};
+use crate::model::{Config, SkillTarget, SkillsField};
+use crate::ui::SYM_OK;
+
+pub(crate) fn run(
+    repo: &str,
+    skill_names: &[String],
+    global: bool,
+    unattended: bool,
+) -> Result<()> {
+    print_banner();
+    println!();
+
+    let config_path = config_path_for_edit(global)?;
+    let source = normalize_source(repo)?;
+    let mut cfg = load_or_default_config(&config_path)?;
+    let plan = build_removal_plan(&cfg, &source, skill_names)?;
+
+    if let RemovalPlan::Noop { summary } = &plan {
+        println!("{WARNING}!{RESET} {summary}");
+        return Ok(());
+    }
+
+    print_removal_preview(&config_path, &source, &plan);
+    if !unattended && !confirm_removal()? {
+        println!("{WARNING}!{RESET} remove cancelled");
+        return Ok(());
+    }
+
+    let summary = apply_removal_plan(&mut cfg, plan);
+    save_config(&config_path, &cfg)?;
+
+    println!();
+    println!(
+        "{SUCCESS}{SYM_OK}{RESET} Updated {ACCENT}{}{RESET}",
+        config_path.display()
+    );
+    println!("  {summary}");
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RemovalPlan {
+    Noop {
+        summary: String,
+    },
+    RemoveSource {
+        index: usize,
+    },
+    RemoveSkills {
+        index: usize,
+        removed: Vec<String>,
+        remaining: Vec<String>,
+        missing: Vec<String>,
+    },
+}
+
+fn build_removal_plan(cfg: &Config, source: &str, skill_names: &[String]) -> Result<RemovalPlan> {
+    let Some((index, entry)) = cfg
+        .skills
+        .iter()
+        .enumerate()
+        .find(|(_, entry)| source_matches(&entry.source, source))
+    else {
+        return Ok(RemovalPlan::Noop {
+            summary: format!("no source matched {source}"),
+        });
+    };
+
+    if skill_names.is_empty() {
+        return Ok(RemovalPlan::RemoveSource { index });
+    }
+
+    if matches!(entry.skills, SkillsField::Wildcard(ref wildcard) if wildcard == "*") {
+        return Err(err(format!(
+            "cannot remove specific skills from {source} because it is configured as skills: \"*\""
+        )));
+    }
+
+    let existing = skill_names_from_field(&entry.skills);
+    let requested = dedupe_skill_names(skill_names);
+    let removed = requested
+        .intersection(&existing)
+        .cloned()
+        .collect::<Vec<_>>();
+    let missing = requested.difference(&existing).cloned().collect::<Vec<_>>();
+
+    if removed.is_empty() {
+        return Ok(RemovalPlan::Noop {
+            summary: format!(
+                "no changes for {source}; requested skills were not present{}",
+                format_missing_suffix(&missing)
+            ),
+        });
+    }
+
+    let remaining = existing.difference(&requested).cloned().collect::<Vec<_>>();
+    if remaining.is_empty() {
+        return Ok(RemovalPlan::RemoveSource { index });
+    }
+
+    Ok(RemovalPlan::RemoveSkills {
+        index,
+        removed,
+        remaining,
+        missing,
+    })
+}
+
+fn dedupe_skill_names(skill_names: &[String]) -> BTreeSet<String> {
+    skill_names.iter().cloned().collect()
+}
+
+fn print_removal_preview(config_path: &std::path::Path, source: &str, plan: &RemovalPlan) {
+    println!("Config: {}", config_path.display());
+    println!("Source: {source}");
+
+    match plan {
+        RemovalPlan::Noop { summary } => println!("Result: {summary}"),
+        RemovalPlan::RemoveSource { .. } => {
+            println!("Change: remove source entry");
+            println!("Result: source will be deleted");
+        }
+        RemovalPlan::RemoveSkills {
+            removed,
+            remaining,
+            missing,
+            ..
+        } => {
+            println!("Change: remove skills [{}]", removed.join(", "));
+            if !missing.is_empty() {
+                println!("Ignored: requested but absent [{}]", missing.join(", "));
+            }
+            println!("Result: source will keep [{}]", remaining.join(", "));
+        }
+    }
+}
+
+fn confirm_removal() -> Result<bool> {
+    if !io::stdin().is_terminal() {
+        return Err(err(
+            "remove needs confirmation but stdin is not a terminal; pass -u to continue non-interactively",
+        ));
+    }
+
+    print!("{ACCENT}Proceed?{RESET} [y/N] ");
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    Ok(matches!(input.trim(), "y" | "Y" | "yes"))
+}
+
+fn apply_removal_plan(cfg: &mut Config, plan: RemovalPlan) -> String {
+    match plan {
+        RemovalPlan::Noop { summary } => summary,
+        RemovalPlan::RemoveSource { index } => {
+            let removed = cfg.skills.remove(index);
+            format!("removed source {}", removed.source)
+        }
+        RemovalPlan::RemoveSkills {
+            index,
+            removed,
+            remaining,
+            missing,
+        } => {
+            let source = cfg.skills[index].source.clone();
+            cfg.skills[index].skills =
+                SkillsField::List(remaining.iter().cloned().map(SkillTarget::Name).collect());
+
+            if missing.is_empty() {
+                format!(
+                    "removed {count} skill{suffix} from {source}",
+                    count = removed.len(),
+                    suffix = if removed.len() == 1 { "" } else { "s" }
+                )
+            } else {
+                format!(
+                    "removed {count} skill{suffix} from {source}; ignored absent [{missing}]",
+                    count = removed.len(),
+                    suffix = if removed.len() == 1 { "" } else { "s" },
+                    missing = missing.join(", ")
+                )
+            }
+        }
+    }
+}
+
+fn format_missing_suffix(missing: &[String]) -> String {
+    if missing.is_empty() {
+        String::new()
+    } else {
+        format!(" [{}]", missing.join(", "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::SourceSpec;
+
+    fn config_with_skills(source: &str, skills: SkillsField) -> Config {
+        Config {
+            skills: vec![SourceSpec {
+                source: source.into(),
+                branch: None,
+                git_ref: None,
+                skills,
+            }],
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn build_removal_plan_removes_entire_source_without_skill_filter() {
+        let cfg = config_with_skills(
+            "https://github.com/org/repo",
+            SkillsField::List(vec![SkillTarget::Name("alpha".into())]),
+        );
+
+        let plan = build_removal_plan(&cfg, "https://github.com/org/repo", &[]).expect("plan");
+        assert!(matches!(plan, RemovalPlan::RemoveSource { index: 0 }));
+    }
+
+    #[test]
+    fn build_removal_plan_removes_selected_skills() {
+        let cfg = config_with_skills(
+            "https://github.com/org/repo",
+            SkillsField::List(vec![
+                SkillTarget::Name("alpha".into()),
+                SkillTarget::Name("beta".into()),
+            ]),
+        );
+
+        let plan = build_removal_plan(&cfg, "https://github.com/org/repo", &["alpha".into()])
+            .expect("plan");
+
+        assert!(matches!(
+            plan,
+            RemovalPlan::RemoveSkills {
+                removed,
+                remaining,
+                missing,
+                ..
+            } if removed == vec!["alpha"] && remaining == vec!["beta"] && missing.is_empty()
+        ));
+    }
+
+    #[test]
+    fn build_removal_plan_removes_source_when_last_skill_is_removed() {
+        let cfg = config_with_skills(
+            "https://github.com/org/repo",
+            SkillsField::List(vec![SkillTarget::Name("alpha".into())]),
+        );
+
+        let plan = build_removal_plan(&cfg, "https://github.com/org/repo", &["alpha".into()])
+            .expect("plan");
+        assert!(matches!(plan, RemovalPlan::RemoveSource { .. }));
+    }
+
+    #[test]
+    fn build_removal_plan_rejects_selective_remove_from_wildcard() {
+        let cfg = config_with_skills(
+            "https://github.com/org/repo",
+            SkillsField::Wildcard("*".into()),
+        );
+
+        let err = build_removal_plan(&cfg, "https://github.com/org/repo", &["alpha".into()])
+            .expect_err("error");
+        assert!(err.to_string().contains("skills: \"*\""));
+    }
+
+    #[test]
+    fn build_removal_plan_matches_normalized_existing_source() {
+        let cfg = config_with_skills(
+            "http://github.com/org/repo.git/",
+            SkillsField::List(vec![SkillTarget::Name("alpha".into())]),
+        );
+
+        let plan = build_removal_plan(&cfg, "https://github.com/org/repo", &[]).expect("plan");
+        assert!(matches!(plan, RemovalPlan::RemoveSource { .. }));
+    }
+
+    #[test]
+    fn build_removal_plan_noops_when_source_is_missing() {
+        let cfg = Config::default();
+
+        let plan = build_removal_plan(&cfg, "https://github.com/org/repo", &[]).expect("plan");
+        assert!(matches!(plan, RemovalPlan::Noop { .. }));
+    }
+
+    #[test]
+    fn build_removal_plan_noops_when_requested_skills_are_absent() {
+        let cfg = config_with_skills(
+            "https://github.com/org/repo",
+            SkillsField::List(vec![SkillTarget::Name("alpha".into())]),
+        );
+
+        let plan = build_removal_plan(&cfg, "https://github.com/org/repo", &["beta".into()])
+            .expect("plan");
+        assert!(matches!(plan, RemovalPlan::Noop { summary } if summary.contains("not present")));
+    }
+
+    #[test]
+    fn apply_removal_plan_updates_remaining_skills() {
+        let mut cfg = config_with_skills(
+            "https://github.com/org/repo",
+            SkillsField::List(vec![
+                SkillTarget::Name("alpha".into()),
+                SkillTarget::Name("beta".into()),
+            ]),
+        );
+
+        let summary = apply_removal_plan(
+            &mut cfg,
+            RemovalPlan::RemoveSkills {
+                index: 0,
+                removed: vec!["alpha".into()],
+                remaining: vec!["beta".into()],
+                missing: vec![],
+            },
+        );
+
+        assert!(summary.contains("removed 1 skill"));
+        assert!(matches!(&cfg.skills[0].skills, SkillsField::List(items) if items.len() == 1));
+    }
+}

--- a/src/home/mod.rs
+++ b/src/home/mod.rs
@@ -2,7 +2,7 @@
 
 mod prompt;
 
-use std::io::{stdout, IsTerminal, Stdout, Write};
+use std::io::{self, stdout, IsTerminal, Stdout, Write};
 use std::time::{Duration, Instant};
 
 use crossterm::cursor::MoveTo;
@@ -12,12 +12,12 @@ use crossterm::style::{Attribute, Print, ResetColor, SetAttribute, SetForeground
 use crossterm::terminal::{self, Clear, ClearType};
 
 use crate::banner::banner_width;
-use crate::cli::SyncArgs;
+use crate::cli::{AddArgs, RemoveArgs, SyncArgs};
 use crate::colors::term;
 use crate::error::Result;
 use crate::tui::{draw_banner_or_fallback, draw_stars, TuiGuard};
 
-use prompt::prompt_sync_args;
+use prompt::{prompt_add_args, prompt_remove_args, prompt_sync_args};
 
 pub(crate) fn run(program_name: &str, default_config: &str) -> Result<()> {
     if !stdout().is_terminal() || std::env::var_os("NO_TUI").is_some() {
@@ -25,7 +25,19 @@ pub(crate) fn run(program_name: &str, default_config: &str) -> Result<()> {
         return Ok(());
     }
 
-    match browse(program_name, default_config)? {
+    loop {
+        let action = browse(program_name, default_config)?;
+        if matches!(action, HomeAction::Quit) {
+            return Ok(());
+        }
+
+        run_action(action, program_name, default_config)?;
+        prompt_return_to_home()?;
+    }
+}
+
+fn run_action(action: HomeAction, program_name: &str, default_config: &str) -> Result<()> {
+    match action {
         HomeAction::Sync(sync) => {
             let config = sync.config.unwrap_or_else(|| default_config.into());
             crate::commands::sync::run(&crate::commands::sync::SyncOptions {
@@ -40,6 +52,13 @@ pub(crate) fn run(program_name: &str, default_config: &str) -> Result<()> {
                 show_banner: true,
             })
         }
+        HomeAction::Add(add) => crate::commands::add::run(&add.repo, &add.skills, add.global),
+        HomeAction::Remove(remove) => crate::commands::remove::run(
+            &remove.repo,
+            &remove.skills,
+            remove.global,
+            remove.unattended,
+        ),
         HomeAction::Init => crate::commands::init::run(false, false),
         HomeAction::List => crate::commands::list::run(false, false, false, None),
         HomeAction::Doctor => crate::commands::doctor::run(false, false, false, None, program_name),
@@ -49,8 +68,20 @@ pub(crate) fn run(program_name: &str, default_config: &str) -> Result<()> {
     }
 }
 
+fn prompt_return_to_home() -> Result<()> {
+    println!();
+    print!("Press Enter to return to the home screen...");
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    Ok(())
+}
+
 enum HomeAction {
     Sync(SyncArgs),
+    Add(AddArgs),
+    Remove(RemoveArgs),
     Init,
     List,
     Doctor,
@@ -62,6 +93,8 @@ enum HomeAction {
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum HomeItemAction {
     Sync,
+    Add,
+    Remove,
     Init,
     List,
     Doctor,
@@ -74,6 +107,8 @@ impl HomeItemAction {
     fn home_action(self) -> Option<HomeAction> {
         match self {
             HomeItemAction::Sync => None,
+            HomeItemAction::Add => None,
+            HomeItemAction::Remove => None,
             HomeItemAction::Init => Some(HomeAction::Init),
             HomeItemAction::List => Some(HomeAction::List),
             HomeItemAction::Doctor => Some(HomeAction::Doctor),
@@ -91,7 +126,7 @@ struct HomeItem {
     action: HomeItemAction,
 }
 
-const HOME_ITEMS: [HomeItem; 7] = [
+const HOME_ITEMS: [HomeItem; 9] = [
     HomeItem {
         title: "init",
         command: "kasetto init [--global] [--force]",
@@ -101,6 +136,16 @@ const HOME_ITEMS: [HomeItem; 7] = [
         title: "sync",
         command: "kasetto sync --config <path-or-url> [--dry-run] [--verbose]",
         action: HomeItemAction::Sync,
+    },
+    HomeItem {
+        title: "add",
+        command: "kasetto add <repo> [--skill <name>] [--global]",
+        action: HomeItemAction::Add,
+    },
+    HomeItem {
+        title: "remove",
+        command: "kasetto remove <repo> [--skill <name>] [--global] [-u]",
+        action: HomeItemAction::Remove,
     },
     HomeItem {
         title: "list",
@@ -163,6 +208,16 @@ fn browse(program_name: &str, default_config: &str) -> Result<HomeAction> {
                             return Ok(HomeAction::Sync(sync));
                         }
                     }
+                    KeyCode::Char('a') => {
+                        if let Some(add) = prompt_add_args(&mut guard.stdout, program_name)? {
+                            return Ok(HomeAction::Add(add));
+                        }
+                    }
+                    KeyCode::Char('r') => {
+                        if let Some(remove) = prompt_remove_args(&mut guard.stdout, program_name)? {
+                            return Ok(HomeAction::Remove(remove));
+                        }
+                    }
                     KeyCode::Char('l') => return Ok(HomeAction::List),
                     KeyCode::Char('d') => return Ok(HomeAction::Doctor),
                     KeyCode::Char('c') => return Ok(HomeAction::Clean),
@@ -171,6 +226,20 @@ fn browse(program_name: &str, default_config: &str) -> Result<HomeAction> {
                         let action = HOME_ITEMS[selected].action;
                         if let Some(ha) = action.home_action() {
                             return Ok(ha);
+                        }
+                        if action == HomeItemAction::Add {
+                            if let Some(add) = prompt_add_args(&mut guard.stdout, program_name)? {
+                                return Ok(HomeAction::Add(add));
+                            }
+                            continue;
+                        }
+                        if action == HomeItemAction::Remove {
+                            if let Some(remove) =
+                                prompt_remove_args(&mut guard.stdout, program_name)?
+                            {
+                                return Ok(HomeAction::Remove(remove));
+                            }
+                            continue;
                         }
                         if let Some(sync) =
                             prompt_sync_args(&mut guard.stdout, program_name, default_config)?
@@ -255,7 +324,7 @@ fn draw(
 
     let footer_row = height.saturating_sub(2) as u16;
     let hint = format!(
-        "q quit   ↑/↓ or j/k move   Enter run   i/s/l/d/c/u   sync args: {} [flags]",
+        "q quit   ↑/↓ or j/k move   Enter run   i/s/a/r/l/d/c/u   sync args: {} [flags]",
         command_text(program_name, &HOME_ITEMS[1])
     );
     execute!(
@@ -277,6 +346,8 @@ fn print_sleeping_hint(program_name: &str, default_config: &str) {
     println!("Try one of these next:");
     println!("  {} init", program_name);
     println!("  {} sync --config {}", program_name, default_config);
+    println!("  {} add https://github.com/org/skills", program_name);
+    println!("  {} remove https://github.com/org/skills", program_name);
     println!("  {} list", program_name);
     println!("  {} doctor", program_name);
     println!("  {} clean", program_name);

--- a/src/home/prompt.rs
+++ b/src/home/prompt.rs
@@ -1,4 +1,6 @@
+use std::collections::BTreeSet;
 use std::io::{Stdout, Write};
+use std::path::PathBuf;
 
 use clap::Parser;
 use crossterm::cursor::MoveTo;
@@ -7,10 +9,14 @@ use crossterm::execute;
 use crossterm::style::{Attribute, Print, ResetColor, SetAttribute, SetForegroundColor};
 use crossterm::terminal::{self, Clear, ClearType};
 
-use crate::cli::{Cli, Commands, SyncArgs};
+use crate::cli::{AddArgs, Cli, Commands, RemoveArgs, SyncArgs};
 use crate::colors::term;
+use crate::commands::add::{
+    config_path_for_edit, discover_available_skills, load_or_default_config, normalize_source,
+    skill_names_from_field,
+};
 use crate::error::Result;
-use crate::model::{resolve_scope, Scope};
+use crate::model::{resolve_scope, Scope, SkillsField};
 use crate::tui::draw_banner_or_fallback;
 
 pub(super) fn prompt_sync_args(
@@ -54,6 +60,157 @@ pub(super) fn prompt_sync_args(
                 input.push_str(&text);
                 error = None;
             }
+            Event::Resize(_, _) => {}
+            _ => {}
+        }
+    }
+}
+
+pub(super) fn prompt_add_args(stdout: &mut Stdout, program_name: &str) -> Result<Option<AddArgs>> {
+    let mut repo_input = String::new();
+    let mut global = false;
+    let mut error = None::<String>;
+
+    loop {
+        draw_add_repo_prompt(stdout, program_name, &repo_input, global, error.as_deref())?;
+        match event::read()? {
+            Event::Key(key) if key.kind != KeyEventKind::Release => match key.code {
+                KeyCode::Enter => {
+                    let repo = match normalize_source(&repo_input) {
+                        Ok(repo) => repo,
+                        Err(message) => {
+                            error = Some(message.to_string());
+                            continue;
+                        }
+                    };
+
+                    draw_add_loading_prompt(stdout, program_name, &repo, global)?;
+
+                    let available = match discover_available_skills(&repo) {
+                        Ok(available) => available,
+                        Err(message) => {
+                            error = Some(message.to_string());
+                            continue;
+                        }
+                    };
+
+                    if available.is_empty() {
+                        error = Some(format!("no skills found in source: {repo}"));
+                        continue;
+                    }
+
+                    if let Some(skills) = prompt_add_skill_selection(
+                        stdout,
+                        program_name,
+                        &repo,
+                        &available,
+                        &mut global,
+                    )? {
+                        return Ok(Some(AddArgs {
+                            repo,
+                            skills,
+                            global,
+                        }));
+                    }
+
+                    error = None;
+                }
+                KeyCode::Esc => return Ok(None),
+                KeyCode::Backspace => {
+                    repo_input.pop();
+                    error = None;
+                }
+                KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    repo_input.clear();
+                    error = None;
+                }
+                KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    global = !global;
+                    error = None;
+                }
+                KeyCode::Char(ch) => {
+                    repo_input.push(ch);
+                    error = None;
+                }
+                _ => {}
+            },
+            Event::Paste(text) => {
+                repo_input.push_str(&text);
+                error = None;
+            }
+            Event::Resize(_, _) => {}
+            _ => {}
+        }
+    }
+}
+
+pub(super) fn prompt_remove_args(
+    stdout: &mut Stdout,
+    program_name: &str,
+) -> Result<Option<RemoveArgs>> {
+    let mut selected = 0usize;
+    let mut global = false;
+    let mut error = None::<String>;
+
+    loop {
+        let loaded = load_installed_sources(global)?;
+        if selected >= loaded.entries.len() {
+            selected = loaded.entries.len().saturating_sub(1);
+        }
+
+        draw_remove_source_prompt(stdout, program_name, &loaded, selected, error.as_deref())?;
+
+        match event::read()? {
+            Event::Key(key) if key.kind != KeyEventKind::Release => match key.code {
+                KeyCode::Up | KeyCode::Char('k') => {
+                    selected = selected.saturating_sub(1);
+                    error = None;
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    selected = (selected + 1).min(loaded.entries.len().saturating_sub(1));
+                    error = None;
+                }
+                KeyCode::Enter => {
+                    let Some(entry) = loaded.entries.get(selected).cloned() else {
+                        continue;
+                    };
+
+                    match entry.skills {
+                        InstalledSkills::All => {
+                            return Ok(Some(RemoveArgs {
+                                repo: entry.source,
+                                skills: vec![],
+                                global,
+                                unattended: false,
+                            }));
+                        }
+                        InstalledSkills::Explicit(skills) => {
+                            if let Some(selected_skills) = prompt_remove_skill_selection(
+                                stdout,
+                                program_name,
+                                &entry.source,
+                                &skills,
+                                &mut global,
+                            )? {
+                                return Ok(Some(RemoveArgs {
+                                    repo: entry.source,
+                                    skills: selected_skills,
+                                    global,
+                                    unattended: false,
+                                }));
+                            }
+                            error = None;
+                        }
+                    }
+                }
+                KeyCode::Esc => return Ok(None),
+                KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    global = !global;
+                    selected = 0;
+                    error = None;
+                }
+                _ => {}
+            },
             Event::Resize(_, _) => {}
             _ => {}
         }
@@ -181,6 +338,754 @@ fn draw_sync_prompt(
     Ok(())
 }
 
+fn draw_add_repo_prompt(
+    stdout: &mut Stdout,
+    program_name: &str,
+    input: &str,
+    global: bool,
+    error: Option<&str>,
+) -> Result<()> {
+    let (width, height) = terminal::size()?;
+    let width = width as usize;
+    let height = height as usize;
+
+    execute!(stdout, MoveTo(0, 0), Clear(ClearType::All))?;
+
+    let title = format!("{program_name} | カセット");
+    let mut row = draw_banner_or_fallback(stdout, &title, width, height, 0)?;
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::INFO),
+        SetAttribute(Attribute::Bold),
+        Print("Add Args"),
+        SetAttribute(Attribute::Reset),
+        ResetColor
+    )?;
+    row = row.saturating_add(1);
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        Print("Enter a repo or local source, then press Enter to discover skills.")
+    )?;
+    row = row.saturating_add(1);
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::SECONDARY),
+        Print(format!(
+            "Example: {} https://github.com/org/skills --skill code-reviewer",
+            program_name
+        )),
+        ResetColor
+    )?;
+    row = row.saturating_add(1);
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::SECONDARY),
+        Print(format!(
+            "Target config: {} (Ctrl-G toggles)",
+            config_target_label(global)
+        )),
+        ResetColor
+    )?;
+    row = row.saturating_add(1);
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::SECONDARY),
+        Print(format!(
+            "Global config: {} https://github.com/org/skills --global",
+            program_name
+        )),
+        ResetColor
+    )?;
+    row = row.saturating_add(2);
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::ACCENT),
+        Print("add> "),
+        ResetColor
+    )?;
+
+    if input.is_empty() {
+        execute!(
+            stdout,
+            SetForegroundColor(term::SECONDARY),
+            Print("https://github.com/org/skills"),
+            ResetColor
+        )?;
+    } else {
+        execute!(stdout, Print(input))?;
+    }
+    let input_row = row;
+    row = row.saturating_add(2);
+
+    if let Some(message) = error {
+        execute!(
+            stdout,
+            MoveTo(0, row),
+            SetForegroundColor(term::ERROR),
+            Print(message),
+            ResetColor
+        )?;
+    }
+
+    let footer_row = height.saturating_sub(2) as u16;
+    let input_col = if input.is_empty() {
+        5
+    } else {
+        5 + input.chars().count() as u16
+    };
+    execute!(
+        stdout,
+        MoveTo(0, footer_row),
+        SetForegroundColor(term::SECONDARY),
+        Print("Enter continue   Esc cancel   Ctrl-U clear   Ctrl-G toggle target"),
+        ResetColor,
+        MoveTo(input_col, input_row)
+    )?;
+
+    stdout.flush()?;
+    Ok(())
+}
+
+fn draw_add_loading_prompt(
+    stdout: &mut Stdout,
+    program_name: &str,
+    repo: &str,
+    global: bool,
+) -> Result<()> {
+    let (width, height) = terminal::size()?;
+    let width = width as usize;
+    let height = height as usize;
+
+    execute!(stdout, MoveTo(0, 0), Clear(ClearType::All))?;
+
+    let title = format!("{program_name} | カセット");
+    let mut row = draw_banner_or_fallback(stdout, &title, width, height, 0)?;
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::INFO),
+        SetAttribute(Attribute::Bold),
+        Print("Add Skills"),
+        SetAttribute(Attribute::Reset),
+        ResetColor
+    )?;
+    row = row.saturating_add(1);
+
+    execute!(stdout, MoveTo(0, row), Print(format!("Source: {repo}")))?;
+    row = row.saturating_add(1);
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::SECONDARY),
+        Print(format!("Target config: {}", config_target_label(global))),
+        ResetColor
+    )?;
+    row = row.saturating_add(2);
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::ACCENT),
+        SetAttribute(Attribute::Bold),
+        Print("Loading skills..."),
+        SetAttribute(Attribute::Reset),
+        ResetColor
+    )?;
+
+    stdout.flush()?;
+    Ok(())
+}
+
+fn draw_add_skill_prompt(
+    stdout: &mut Stdout,
+    program_name: &str,
+    repo: &str,
+    available: &[String],
+    selected: usize,
+    chosen: &BTreeSet<String>,
+    global: bool,
+    error: Option<&str>,
+) -> Result<()> {
+    let (width, height) = terminal::size()?;
+    let width = width as usize;
+    let height = height as usize;
+
+    execute!(stdout, MoveTo(0, 0), Clear(ClearType::All))?;
+
+    let title = format!("{program_name} | カセット");
+    let mut row = draw_banner_or_fallback(stdout, &title, width, height, 0)?;
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::INFO),
+        SetAttribute(Attribute::Bold),
+        Print("Add Skills"),
+        SetAttribute(Attribute::Reset),
+        ResetColor
+    )?;
+    row = row.saturating_add(1);
+
+    execute!(stdout, MoveTo(0, row), Print(format!("Source: {repo}")))?;
+    row = row.saturating_add(1);
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::SECONDARY),
+        Print("Select skills with Space. Press Right to select all."),
+        ResetColor
+    )?;
+    row = row.saturating_add(1);
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::SECONDARY),
+        Print(format!(
+            "Target config: {} (Ctrl-G toggles)",
+            config_target_label(global)
+        )),
+        ResetColor
+    )?;
+    row = row.saturating_add(2);
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::SECONDARY),
+        Print(format!("Selected: {} of {}", chosen.len(), available.len())),
+        ResetColor
+    )?;
+    row = row.saturating_add(2);
+
+    let max_items = height.saturating_sub(row as usize + 3).max(1);
+    let (start, end) = visible_window(selected, available.len(), max_items);
+    for (index, skill) in available[start..end].iter().enumerate() {
+        let actual = start + index;
+        execute!(stdout, MoveTo(0, row))?;
+        if actual == selected {
+            execute!(
+                stdout,
+                SetForegroundColor(term::ACCENT),
+                SetAttribute(Attribute::Bold),
+                Print("› "),
+                SetAttribute(Attribute::Reset),
+                ResetColor
+            )?;
+        } else {
+            execute!(
+                stdout,
+                SetForegroundColor(term::SECONDARY),
+                Print("  "),
+                ResetColor
+            )?;
+        }
+
+        let marker = if chosen.contains(skill) { "[x]" } else { "[ ]" };
+        execute!(stdout, Print(format!("{marker} {skill}")))?;
+        row = row.saturating_add(1);
+    }
+
+    if let Some(message) = error {
+        execute!(
+            stdout,
+            MoveTo(0, row),
+            SetForegroundColor(term::ERROR),
+            Print(message),
+            ResetColor
+        )?;
+    }
+
+    let footer_row = height.saturating_sub(2) as u16;
+    execute!(
+        stdout,
+        MoveTo(0, footer_row),
+        SetForegroundColor(term::SECONDARY),
+        Print("Enter add   Space toggle   Right select all   Left clear all   Esc back   Ctrl-G toggle target   ↑/↓ or j/k move"),
+        ResetColor
+    )?;
+
+    stdout.flush()?;
+    Ok(())
+}
+
+fn prompt_add_skill_selection(
+    stdout: &mut Stdout,
+    program_name: &str,
+    repo: &str,
+    available: &[String],
+    global: &mut bool,
+) -> Result<Option<Vec<String>>> {
+    let mut selected = 0usize;
+    let mut chosen = BTreeSet::new();
+    let mut error = None::<String>;
+
+    loop {
+        draw_add_skill_prompt(
+            stdout,
+            program_name,
+            repo,
+            available,
+            selected,
+            &chosen,
+            *global,
+            error.as_deref(),
+        )?;
+
+        match event::read()? {
+            Event::Key(key) if key.kind != KeyEventKind::Release => match key.code {
+                KeyCode::Up | KeyCode::Char('k') => {
+                    selected = selected.saturating_sub(1);
+                    error = None;
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    selected = (selected + 1).min(available.len().saturating_sub(1));
+                    error = None;
+                }
+                KeyCode::Char(' ') => {
+                    let skill = available[selected].clone();
+                    if !chosen.insert(skill.clone()) {
+                        chosen.remove(&skill);
+                    }
+                    error = None;
+                }
+                KeyCode::Right => {
+                    chosen = available.iter().cloned().collect();
+                    error = None;
+                }
+                KeyCode::Left => {
+                    chosen.clear();
+                    error = None;
+                }
+                KeyCode::Enter => {
+                    if chosen.is_empty() {
+                        error =
+                            Some("Select one or more skills, or press Right to select all.".into());
+                    } else if chosen.len() == available.len() {
+                        return Ok(Some(vec![]));
+                    } else {
+                        return Ok(Some(chosen.iter().cloned().collect()));
+                    }
+                }
+                KeyCode::Esc => return Ok(None),
+                KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    *global = !*global;
+                    error = None;
+                }
+                _ => {}
+            },
+            Event::Resize(_, _) => {}
+            _ => {}
+        }
+    }
+}
+
+#[derive(Clone)]
+struct LoadedSources {
+    path: PathBuf,
+    global: bool,
+    entries: Vec<InstalledSource>,
+}
+
+#[derive(Clone)]
+struct InstalledSource {
+    source: String,
+    skills: InstalledSkills,
+}
+
+#[derive(Clone)]
+enum InstalledSkills {
+    All,
+    Explicit(Vec<String>),
+}
+
+fn load_installed_sources(global: bool) -> Result<LoadedSources> {
+    let path = config_path_for_edit(global)?;
+    let cfg = load_or_default_config(&path)?;
+    let mut entries = cfg
+        .skills
+        .into_iter()
+        .map(|entry| InstalledSource {
+            source: normalize_source(&entry.source)
+                .unwrap_or_else(|_| entry.source.trim().to_string()),
+            skills: match entry.skills {
+                SkillsField::Wildcard(_) => InstalledSkills::All,
+                SkillsField::List(items) => {
+                    let mut skills = skill_names_from_field(&SkillsField::List(items))
+                        .into_iter()
+                        .collect::<Vec<_>>();
+                    skills.sort();
+                    InstalledSkills::Explicit(skills)
+                }
+            },
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| left.source.cmp(&right.source));
+
+    Ok(LoadedSources {
+        path,
+        global,
+        entries,
+    })
+}
+
+fn draw_remove_source_prompt(
+    stdout: &mut Stdout,
+    program_name: &str,
+    loaded: &LoadedSources,
+    selected: usize,
+    error: Option<&str>,
+) -> Result<()> {
+    let (width, height) = terminal::size()?;
+    let width = width as usize;
+    let height = height as usize;
+
+    execute!(stdout, MoveTo(0, 0), Clear(ClearType::All))?;
+
+    let title = format!("{program_name} | カセット");
+    let mut row = draw_banner_or_fallback(stdout, &title, width, height, 0)?;
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::INFO),
+        SetAttribute(Attribute::Bold),
+        Print("Remove Source"),
+        SetAttribute(Attribute::Reset),
+        ResetColor
+    )?;
+    row = row.saturating_add(1);
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        Print(format!("Config: {}", loaded.path.display()))
+    )?;
+    row = row.saturating_add(1);
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::SECONDARY),
+        Print(format!(
+            "Target config: {} (Ctrl-G toggles)",
+            config_target_label(loaded.global)
+        )),
+        ResetColor
+    )?;
+    row = row.saturating_add(2);
+
+    if loaded.entries.is_empty() {
+        execute!(
+            stdout,
+            MoveTo(0, row),
+            SetForegroundColor(term::SECONDARY),
+            Print("No configured sources found. Toggle target with Ctrl-G or press Esc."),
+            ResetColor
+        )?;
+        row = row.saturating_add(2);
+    } else {
+        execute!(
+            stdout,
+            MoveTo(0, row),
+            Print("Select a source to remove or inspect its configured skills:")
+        )?;
+        row = row.saturating_add(1);
+
+        let max_items = height.saturating_sub(row as usize + 3);
+        let (start, end) = visible_window(selected, loaded.entries.len(), max_items.max(1));
+        for (index, entry) in loaded.entries[start..end].iter().enumerate() {
+            let actual = start + index;
+            execute!(stdout, MoveTo(0, row))?;
+            if actual == selected {
+                execute!(
+                    stdout,
+                    SetForegroundColor(term::ACCENT),
+                    SetAttribute(Attribute::Bold),
+                    Print("› "),
+                    Print(&entry.source),
+                    SetAttribute(Attribute::Reset),
+                    ResetColor
+                )?;
+            } else {
+                execute!(
+                    stdout,
+                    SetForegroundColor(term::SECONDARY),
+                    Print("  "),
+                    ResetColor,
+                    Print(&entry.source)
+                )?;
+            }
+
+            execute!(
+                stdout,
+                SetForegroundColor(term::SECONDARY),
+                Print(format!("  ({})", installed_summary(&entry.skills))),
+                ResetColor
+            )?;
+            row = row.saturating_add(1);
+        }
+    }
+
+    if let Some(message) = error {
+        execute!(
+            stdout,
+            MoveTo(0, row),
+            SetForegroundColor(term::ERROR),
+            Print(message),
+            ResetColor
+        )?;
+    }
+
+    let footer_row = height.saturating_sub(2) as u16;
+    execute!(
+        stdout,
+        MoveTo(0, footer_row),
+        SetForegroundColor(term::SECONDARY),
+        Print("Enter continue   Esc cancel   Ctrl-G toggle target   ↑/↓ or j/k move"),
+        ResetColor
+    )?;
+
+    stdout.flush()?;
+    Ok(())
+}
+
+fn prompt_remove_skill_selection(
+    stdout: &mut Stdout,
+    program_name: &str,
+    source: &str,
+    skills: &[String],
+    global: &mut bool,
+) -> Result<Option<Vec<String>>> {
+    let mut selected = 0usize;
+    let mut chosen = BTreeSet::new();
+    let mut error = None::<String>;
+
+    loop {
+        draw_remove_skill_prompt(
+            stdout,
+            program_name,
+            source,
+            skills,
+            selected,
+            &chosen,
+            *global,
+            error.as_deref(),
+        )?;
+
+        match event::read()? {
+            Event::Key(key) if key.kind != KeyEventKind::Release => match key.code {
+                KeyCode::Up | KeyCode::Char('k') => {
+                    selected = selected.saturating_sub(1);
+                    error = None;
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    selected = (selected + 1).min(skills.len());
+                    error = None;
+                }
+                KeyCode::Char(' ') => {
+                    if selected > 0 {
+                        let skill = skills[selected - 1].clone();
+                        if !chosen.insert(skill.clone()) {
+                            chosen.remove(&skill);
+                        }
+                        error = None;
+                    }
+                }
+                KeyCode::Enter => {
+                    if selected == 0 {
+                        return Ok(Some(vec![]));
+                    }
+                    if chosen.is_empty() {
+                        error = Some("Select one or more skills, or choose All skills.".into());
+                    } else {
+                        return Ok(Some(chosen.iter().cloned().collect()));
+                    }
+                }
+                KeyCode::Esc => return Ok(None),
+                KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    *global = !*global;
+                    error = None;
+                }
+                _ => {}
+            },
+            Event::Resize(_, _) => {}
+            _ => {}
+        }
+    }
+}
+
+fn draw_remove_skill_prompt(
+    stdout: &mut Stdout,
+    program_name: &str,
+    source: &str,
+    skills: &[String],
+    selected: usize,
+    chosen: &BTreeSet<String>,
+    global: bool,
+    error: Option<&str>,
+) -> Result<()> {
+    let (width, height) = terminal::size()?;
+    let width = width as usize;
+    let height = height as usize;
+
+    execute!(stdout, MoveTo(0, 0), Clear(ClearType::All))?;
+
+    let title = format!("{program_name} | カセット");
+    let mut row = draw_banner_or_fallback(stdout, &title, width, height, 0)?;
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::INFO),
+        SetAttribute(Attribute::Bold),
+        Print("Remove Skills"),
+        SetAttribute(Attribute::Reset),
+        ResetColor
+    )?;
+    row = row.saturating_add(1);
+
+    execute!(stdout, MoveTo(0, row), Print(format!("Source: {source}")))?;
+    row = row.saturating_add(1);
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        SetForegroundColor(term::SECONDARY),
+        Print(format!(
+            "Target config: {} (Ctrl-G toggles)",
+            config_target_label(global)
+        )),
+        ResetColor
+    )?;
+    row = row.saturating_add(2);
+
+    execute!(
+        stdout,
+        MoveTo(0, row),
+        Print(
+            "Choose All skills to remove the whole source, or select individual skills with Space:"
+        )
+    )?;
+    row = row.saturating_add(1);
+
+    let mut items = vec![("All skills (remove source entry)".to_string(), false)];
+    items.extend(
+        skills
+            .iter()
+            .map(|skill| (skill.clone(), chosen.contains(skill))),
+    );
+
+    let max_items = height.saturating_sub(row as usize + 3).max(1);
+    let (start, end) = visible_window(selected, items.len(), max_items);
+    for (index, (label, checked)) in items[start..end].iter().enumerate() {
+        let actual = start + index;
+        execute!(stdout, MoveTo(0, row))?;
+        if actual == selected {
+            execute!(
+                stdout,
+                SetForegroundColor(term::ACCENT),
+                SetAttribute(Attribute::Bold),
+                Print("› "),
+                SetAttribute(Attribute::Reset),
+                ResetColor
+            )?;
+        } else {
+            execute!(
+                stdout,
+                SetForegroundColor(term::SECONDARY),
+                Print("  "),
+                ResetColor
+            )?;
+        }
+
+        let marker = if actual == 0 {
+            "( )"
+        } else if *checked {
+            "[x]"
+        } else {
+            "[ ]"
+        };
+        execute!(stdout, Print(format!("{marker} {label}")))?;
+        row = row.saturating_add(1);
+    }
+
+    if let Some(message) = error {
+        execute!(
+            stdout,
+            MoveTo(0, row),
+            SetForegroundColor(term::ERROR),
+            Print(message),
+            ResetColor
+        )?;
+    }
+
+    let footer_row = height.saturating_sub(2) as u16;
+    execute!(
+        stdout,
+        MoveTo(0, footer_row),
+        SetForegroundColor(term::SECONDARY),
+        Print("Enter confirm   Space toggle   Esc back   Ctrl-G toggle target   ↑/↓ or j/k move"),
+        ResetColor
+    )?;
+
+    stdout.flush()?;
+    Ok(())
+}
+
+fn installed_summary(skills: &InstalledSkills) -> String {
+    match skills {
+        InstalledSkills::All => "all skills".into(),
+        InstalledSkills::Explicit(skills) => {
+            format!("{} skill{}", skills.len(), pluralize(skills.len()))
+        }
+    }
+}
+
+fn visible_window(selected: usize, total: usize, max_items: usize) -> (usize, usize) {
+    if total <= max_items {
+        return (0, total);
+    }
+
+    let half = max_items / 2;
+    let mut start = selected.saturating_sub(half);
+    if start + max_items > total {
+        start = total.saturating_sub(max_items);
+    }
+    (start, (start + max_items).min(total))
+}
+
+fn config_target_label(global: bool) -> &'static str {
+    if global {
+        "global"
+    } else {
+        "local"
+    }
+}
+
+fn pluralize(count: usize) -> &'static str {
+    if count == 1 {
+        ""
+    } else {
+        "s"
+    }
+}
+
 fn parse_sync_args(program_name: &str, input: &str) -> std::result::Result<SyncArgs, String> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
@@ -210,6 +1115,58 @@ fn parse_sync_args(program_name: &str, input: &str) -> std::result::Result<SyncA
     }
 }
 
+#[cfg(test)]
+fn parse_add_args(program_name: &str, input: &str) -> std::result::Result<AddArgs, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("Enter a repo or add args to continue.".into());
+    }
+
+    let mut tokens = shlex::split(trimmed)
+        .ok_or_else(|| "Could not parse add args. Check quotes and escaping.".to_string())?;
+
+    if matches!(tokens.first().map(String::as_str), Some("add")) {
+        tokens.remove(0);
+    }
+
+    let argv = std::iter::once(program_name.to_string())
+        .chain(std::iter::once("add".to_string()))
+        .chain(tokens)
+        .collect::<Vec<_>>();
+
+    let cli = Cli::try_parse_from(argv).map_err(|err| err.to_string())?;
+    match cli.command {
+        Some(Commands::Add { add }) => Ok(add),
+        _ => Err("Add args did not resolve to the add command.".into()),
+    }
+}
+
+#[cfg(test)]
+fn parse_remove_args(program_name: &str, input: &str) -> std::result::Result<RemoveArgs, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("Enter a repo or remove args to continue.".into());
+    }
+
+    let mut tokens = shlex::split(trimmed)
+        .ok_or_else(|| "Could not parse remove args. Check quotes and escaping.".to_string())?;
+
+    if matches!(tokens.first().map(String::as_str), Some("remove")) {
+        tokens.remove(0);
+    }
+
+    let argv = std::iter::once(program_name.to_string())
+        .chain(std::iter::once("remove".to_string()))
+        .chain(tokens)
+        .collect::<Vec<_>>();
+
+    let cli = Cli::try_parse_from(argv).map_err(|err| err.to_string())?;
+    match cli.command {
+        Some(Commands::Remove { remove }) => Ok(remove),
+        _ => Err("Remove args did not resolve to the remove command.".into()),
+    }
+}
+
 fn scope_label(scope: Scope) -> &'static str {
     match scope {
         Scope::Global => "global",
@@ -219,7 +1176,7 @@ fn scope_label(scope: Scope) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_sync_args;
+    use super::{parse_add_args, parse_remove_args, parse_sync_args};
 
     #[test]
     fn parse_sync_args_accepts_shorthand_config_path() {
@@ -244,5 +1201,47 @@ mod tests {
         assert!(sync.dry_run);
         assert!(sync.scope.project);
         assert!(!sync.scope.global);
+    }
+
+    #[test]
+    fn parse_add_args_accepts_repo_only() {
+        let add = parse_add_args("kasetto", "https://github.com/org/skills").expect("add");
+        assert_eq!(add.repo, "https://github.com/org/skills");
+        assert!(add.skills.is_empty());
+        assert!(!add.global);
+    }
+
+    #[test]
+    fn parse_add_args_accepts_explicit_command_and_skills() {
+        let add = parse_add_args(
+            "kasetto",
+            "add https://github.com/org/skills --skill code-reviewer --skill docs --global",
+        )
+        .expect("add");
+        assert_eq!(add.repo, "https://github.com/org/skills");
+        assert_eq!(add.skills, vec!["code-reviewer", "docs"]);
+        assert!(add.global);
+    }
+
+    #[test]
+    fn parse_remove_args_accepts_repo_only() {
+        let remove = parse_remove_args("kasetto", "https://github.com/org/skills").expect("remove");
+        assert_eq!(remove.repo, "https://github.com/org/skills");
+        assert!(remove.skills.is_empty());
+        assert!(!remove.global);
+        assert!(!remove.unattended);
+    }
+
+    #[test]
+    fn parse_remove_args_accepts_command_skills_and_unattended() {
+        let remove = parse_remove_args(
+            "kasetto",
+            "remove https://github.com/org/skills --skill code-reviewer -u --global",
+        )
+        .expect("remove");
+        assert_eq!(remove.repo, "https://github.com/org/skills");
+        assert_eq!(remove.skills, vec!["code-reviewer"]);
+        assert!(remove.global);
+        assert!(remove.unattended);
     }
 }

--- a/src/home/prompt.rs
+++ b/src/home/prompt.rs
@@ -510,15 +510,19 @@ fn draw_add_loading_prompt(
     Ok(())
 }
 
+struct AddSkillPromptView<'a> {
+    program_name: &'a str,
+    repo: &'a str,
+    global: bool,
+    error: Option<&'a str>,
+}
+
 fn draw_add_skill_prompt(
     stdout: &mut Stdout,
-    program_name: &str,
-    repo: &str,
+    view: &AddSkillPromptView<'_>,
     available: &[String],
     selected: usize,
     chosen: &BTreeSet<String>,
-    global: bool,
-    error: Option<&str>,
 ) -> Result<()> {
     let (width, height) = terminal::size()?;
     let width = width as usize;
@@ -526,7 +530,7 @@ fn draw_add_skill_prompt(
 
     execute!(stdout, MoveTo(0, 0), Clear(ClearType::All))?;
 
-    let title = format!("{program_name} | カセット");
+    let title = format!("{} | カセット", view.program_name);
     let mut row = draw_banner_or_fallback(stdout, &title, width, height, 0)?;
 
     execute!(
@@ -540,7 +544,7 @@ fn draw_add_skill_prompt(
     )?;
     row = row.saturating_add(1);
 
-    execute!(stdout, MoveTo(0, row), Print(format!("Source: {repo}")))?;
+    execute!(stdout, MoveTo(0, row), Print(format!("Source: {}", view.repo)))?;
     row = row.saturating_add(1);
 
     execute!(
@@ -558,7 +562,7 @@ fn draw_add_skill_prompt(
         SetForegroundColor(term::SECONDARY),
         Print(format!(
             "Target config: {} (Ctrl-G toggles)",
-            config_target_label(global)
+            config_target_label(view.global)
         )),
         ResetColor
     )?;
@@ -601,7 +605,7 @@ fn draw_add_skill_prompt(
         row = row.saturating_add(1);
     }
 
-    if let Some(message) = error {
+    if let Some(message) = view.error {
         execute!(
             stdout,
             MoveTo(0, row),
@@ -638,13 +642,15 @@ fn prompt_add_skill_selection(
     loop {
         draw_add_skill_prompt(
             stdout,
-            program_name,
-            repo,
+            &AddSkillPromptView {
+                program_name,
+                repo,
+                global: *global,
+                error: error.as_deref(),
+            },
             available,
             selected,
             &chosen,
-            *global,
-            error.as_deref(),
         )?;
 
         match event::read()? {
@@ -879,13 +885,15 @@ fn prompt_remove_skill_selection(
     loop {
         draw_remove_skill_prompt(
             stdout,
-            program_name,
-            source,
+            &RemoveSkillPromptView {
+                program_name,
+                source,
+                global: *global,
+                error: error.as_deref(),
+            },
             skills,
             selected,
             &chosen,
-            *global,
-            error.as_deref(),
         )?;
 
         match event::read()? {
@@ -898,14 +906,12 @@ fn prompt_remove_skill_selection(
                     selected = (selected + 1).min(skills.len());
                     error = None;
                 }
-                KeyCode::Char(' ') => {
-                    if selected > 0 {
-                        let skill = skills[selected - 1].clone();
-                        if !chosen.insert(skill.clone()) {
-                            chosen.remove(&skill);
-                        }
-                        error = None;
+                KeyCode::Char(' ') if selected > 0 => {
+                    let skill = skills[selected - 1].clone();
+                    if !chosen.insert(skill.clone()) {
+                        chosen.remove(&skill);
                     }
+                    error = None;
                 }
                 KeyCode::Enter => {
                     if selected == 0 {
@@ -930,15 +936,19 @@ fn prompt_remove_skill_selection(
     }
 }
 
+struct RemoveSkillPromptView<'a> {
+    program_name: &'a str,
+    source: &'a str,
+    global: bool,
+    error: Option<&'a str>,
+}
+
 fn draw_remove_skill_prompt(
     stdout: &mut Stdout,
-    program_name: &str,
-    source: &str,
+    view: &RemoveSkillPromptView<'_>,
     skills: &[String],
     selected: usize,
     chosen: &BTreeSet<String>,
-    global: bool,
-    error: Option<&str>,
 ) -> Result<()> {
     let (width, height) = terminal::size()?;
     let width = width as usize;
@@ -946,7 +956,7 @@ fn draw_remove_skill_prompt(
 
     execute!(stdout, MoveTo(0, 0), Clear(ClearType::All))?;
 
-    let title = format!("{program_name} | カセット");
+    let title = format!("{} | カセット", view.program_name);
     let mut row = draw_banner_or_fallback(stdout, &title, width, height, 0)?;
 
     execute!(
@@ -960,7 +970,7 @@ fn draw_remove_skill_prompt(
     )?;
     row = row.saturating_add(1);
 
-    execute!(stdout, MoveTo(0, row), Print(format!("Source: {source}")))?;
+    execute!(stdout, MoveTo(0, row), Print(format!("Source: {}", view.source)))?;
     row = row.saturating_add(1);
 
     execute!(
@@ -969,7 +979,7 @@ fn draw_remove_skill_prompt(
         SetForegroundColor(term::SECONDARY),
         Print(format!(
             "Target config: {} (Ctrl-G toggles)",
-            config_target_label(global)
+            config_target_label(view.global)
         )),
         ResetColor
     )?;
@@ -1025,7 +1035,7 @@ fn draw_remove_skill_prompt(
         row = row.saturating_add(1);
     }
 
-    if let Some(message) = error {
+    if let Some(message) = view.error {
         execute!(
             stdout,
             MoveTo(0, row),

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use super::{McpSettingsFormat, McpSettingsTarget};
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub(crate) enum AgentField {
     One(Agent),

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -11,16 +11,21 @@ pub(crate) enum Scope {
     Project,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub(crate) struct Config {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub destination: Option<String>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<Scope>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub agent: Option<AgentField>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub skills: Vec<SourceSpec>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub mcps: Vec<McpSourceSpec>,
 }
 
@@ -69,13 +74,15 @@ mod tests {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub(crate) struct SourceSpec {
     pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
     /// Pin to a git tag, commit SHA, or any ref. Takes priority over `branch`.
     /// When set, no main/master fallback is attempted.
     #[serde(rename = "ref")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub git_ref: Option<String>,
     /// Optional subdirectory inside the source repo/path to use as the skill root.
     /// Supports both `sub-dir` and `sub_dir` YAML keys.
@@ -107,14 +114,17 @@ impl SourceSpec {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub(crate) struct McpSourceSpec {
     pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
     #[serde(rename = "ref")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub git_ref: Option<String>,
     /// Explicit path to an MCP JSON file within the repo (e.g. `.mcp.json`).
     /// When set, skips auto-discovery and uses this file directly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
 }
 
@@ -130,14 +140,14 @@ impl McpSourceSpec {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub(crate) enum SkillsField {
     Wildcard(String),
     List(Vec<SkillTarget>),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 pub(crate) enum SkillTarget {
     Name(String),

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -86,7 +86,12 @@ pub(crate) struct SourceSpec {
     pub git_ref: Option<String>,
     /// Optional subdirectory inside the source repo/path to use as the skill root.
     /// Supports both `sub-dir` and `sub_dir` YAML keys.
-    #[serde(default, rename = "sub-dir", alias = "sub_dir")]
+    #[serde(
+        default,
+        rename = "sub-dir",
+        alias = "sub_dir",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub sub_dir: Option<String>,
     pub skills: SkillsField,
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -6,6 +6,7 @@ mod parse;
 mod remote;
 
 pub(crate) use auth::{auth_env_inline_help, auth_for_request_url, http_fetch_auth_hint};
+pub(crate) use parse::normalize_repo_url;
 pub(crate) use remote::rewrite_browse_to_raw_url;
 
 use std::collections::HashMap;

--- a/src/source/parse.rs
+++ b/src/source/parse.rs
@@ -110,6 +110,19 @@ pub(crate) fn parse_repo_url(url: &str) -> Result<RepoUrl> {
     })
 }
 
+pub(crate) fn normalize_repo_url(url: &str) -> Result<String> {
+    let normalized = match parse_repo_url(url)? {
+        RepoUrl::GitHub { host, owner, repo } => format!("https://{host}/{owner}/{repo}"),
+        RepoUrl::GitLab { host, project_path } => format!("https://{host}/{project_path}"),
+        RepoUrl::Bitbucket {
+            workspace,
+            repo_slug,
+        } => format!("https://bitbucket.org/{workspace}/{repo_slug}"),
+        RepoUrl::Gitea { host, owner, repo } => format!("https://{host}/{owner}/{repo}"),
+    };
+    Ok(normalized)
+}
+
 fn path_segments(path: &str) -> Vec<&str> {
     path.split('/').filter(|s| !s.is_empty()).collect()
 }
@@ -207,5 +220,17 @@ mod tests {
             ),
             "expected Codeberg (Gitea) URL"
         );
+    }
+
+    #[test]
+    fn normalize_repo_url_trims_git_and_trailing_slash() {
+        let url = normalize_repo_url("http://github.com/pivoshenko/kasetto.git/").expect("norm");
+        assert_eq!(url, "https://github.com/pivoshenko/kasetto");
+    }
+
+    #[test]
+    fn normalize_repo_url_preserves_gitlab_subgroups() {
+        let url = normalize_repo_url("https://gitlab.example.com/group/sub/repo/").expect("norm");
+        assert_eq!(url, "https://gitlab.example.com/group/sub/repo");
     }
 }


### PR DESCRIPTION
## Summary
- add `kasetto add` and `kasetto remove` commands to manage skill sources in local or global config files without hand-editing YAML
- normalize repo inputs, support GitHub `org/repo` shorthand, and merge or trim existing source entries safely
- bring add/remove into the home TUI with guided source and skill selection, loading feedback, and return-to-home behavior

## Verification
- cargo fmt --all
- cargo test