### PR TITLE
feat(sync): add command source syncing across supported agents

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -38,3 +38,15 @@ destination: ~/.my-custom-agent/skills
 
 If both `agent` and `destination` are set, `destination` wins. See the
 [configuration reference](./configuration.md#agent-vs-destination) for details.
+
+## Command Support
+
+Kasetto can also sync custom command/workflow files (from the `commands:` config block) for:
+
+- `augment` -> `~/.augment/commands/` (`.augment/commands/` in project scope)
+- `claude-code` -> `~/.claude/commands/` (`.claude/commands/`)
+- `gemini-cli` -> `~/.gemini/commands/` (`.gemini/commands/`)
+- `junie` -> `~/.junie/commands/` (`.junie/commands/`)
+- `roo` -> `~/.roo/commands/` (`.roo/commands/`)
+- `windsurf` -> `~/.windsurf/workflows/` (`.windsurf/workflows/`)
+- `opencode` -> `~/.config/opencode/commands/` (`.opencode/commands/`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,12 @@ mcps:
   - source: https://github.com/org/mcp-pack
   - source: https://github.com/org/monorepo
     path: mcps/my-server/pack.json
+
+# OpenCode commands (optional)
+commands:
+  - source: https://github.com/org/opencode-commands
+    commands:
+      - review-changes
 ```
 
 ## Reference
@@ -62,6 +68,7 @@ mcps:
 | `scope`       | no       | `"global"` (default) or `"project"` - where to install              |
 | `skills`      | **yes**  | List of skill sources                                               |
 | `mcps`        | no       | List of MCP server sources                                          |
+| `commands`    | no       | List of OpenCode command sources                                    |
 
 ### Skill Source Fields
 
@@ -102,6 +109,43 @@ a non-standard layout.
 MCP config files must contain a `mcpServers` object with server definitions. Servers are merged
 into each agent's native settings file (e.g., `.claude.json` for Claude Code, `.cursor/mcp.json`
 for Cursor). See [how sync works](./how-sync-works.md) for merge behavior details.
+
+### Command Source Fields
+
+`commands` installs custom command/workflow files for supported harnesses.
+
+| Key        | Required | Description                                                            |
+| ---------- | -------- | ---------------------------------------------------------------------- |
+| `source`   | **yes**  | Git host URL or local path containing command files                    |
+| `branch`   | no       | Branch for remote sources (default: `main`, falls back to `master`)    |
+| `ref`      | no       | Git tag, commit SHA, or ref - takes priority over `branch`             |
+| `commands` | **yes**  | `"*"` for all, or a list of names / `{ name, path }` objects           |
+
+Kasetto discovers commands in these source locations:
+
+1. `commands/*.{md,toml}`
+2. `workflows/*.{md,toml}`
+3. `.claude/commands/*.{md,toml}`
+4. `.augment/commands/*.{md,toml}`
+5. `.gemini/commands/*.{md,toml}`
+6. `.junie/commands/*.{md,toml}`
+7. `.roo/commands/*.{md,toml}`
+8. `.windsurf/workflows/*.{md,toml}`
+9. `.opencode/commands/*.{md,toml}`
+
+Command names are derived from the file stem (`review-changes.md` or `review-changes.toml` -> `/review-changes`).
+
+Each command entry can be either:
+
+- a string command name (without `.md`)
+- an object with:
+  - `name` (required): command name
+  - `path` (optional): directory that contains `name.md`
+
+!!! note
+
+    Command sync currently writes to these harness directories when selected via `agent`:
+    `claude-code`, `augment`, `gemini-cli`, `junie`, `roo`, `windsurf`, and `opencode`.
 
 ## Remote Configs
 

--- a/kasetto.example.yaml
+++ b/kasetto.example.yaml
@@ -9,3 +9,8 @@ skills:
     skills:
       - name: pivoshenko-brand-guidelines
       - name: skill-creator
+
+commands:
+  - source: https://github.com/acme/opencode-commands
+    commands:
+      - review-changes

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -14,6 +14,7 @@ use crate::ui::{animations_enabled, print_json, SYM_OK};
 struct CleanOutput {
     skills_removed: usize,
     mcps_removed: usize,
+    commands_removed: usize,
     dry_run: bool,
 }
 
@@ -35,9 +36,11 @@ pub(crate) fn run(
 
     let state = lock.state();
     let mcp_assets = lock.list_tracked_asset_ids("mcp");
+    let command_assets = lock.list_tracked_asset_ids("command");
 
     let skills_count = state.skills.len();
     let mcps_count = mcp_assets.len();
+    let commands_count = command_assets.len();
 
     if !dry_run {
         for entry in state.skills.values() {
@@ -62,6 +65,12 @@ pub(crate) fn run(
             }
         }
 
+        for (_id, destination_csv) in &command_assets {
+            for destination in destination_csv.split(',').filter(|s| !s.is_empty()) {
+                let _ = fs::remove_file(destination);
+            }
+        }
+
         lock.clear_all();
         save_lock(&lock, scope, &project_root)?;
     }
@@ -69,6 +78,7 @@ pub(crate) fn run(
     let output = CleanOutput {
         skills_removed: skills_count,
         mcps_removed: mcps_count,
+        commands_removed: commands_count,
         dry_run,
     };
 
@@ -84,7 +94,7 @@ pub(crate) fn run(
         println!();
         println!(
             "  {label_color}{prefix}{RESET}: {}",
-            skills_count + mcps_count
+            skills_count + mcps_count + commands_count
         );
 
         if dry_run {
@@ -129,6 +139,31 @@ pub(crate) fn run(
                     }
                 }
             }
+
+            let command_files: Vec<_> = lock
+                .assets
+                .iter()
+                .filter(|(_, a)| a.kind == "command")
+                .collect();
+            if !command_files.is_empty() {
+                println!("  OpenCode commands:");
+                for (_, a) in command_files {
+                    let destinations: String = a
+                        .destination
+                        .split(',')
+                        .filter(|s| !s.is_empty())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    if color {
+                        println!(
+                            "    {ACCENT}command{RESET} {}  (source: {})",
+                            destinations, a.source
+                        );
+                    } else {
+                        println!("    command {}  (source: {})", destinations, a.source);
+                    }
+                }
+            }
         }
 
         if !dry_run {
@@ -141,4 +176,50 @@ pub(crate) fn run(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fsops::temp_dir;
+    use crate::lock::{load_lock, save_lock, LockFile};
+    use std::sync::{Mutex, OnceLock};
+
+    fn cwd_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn clean_removes_tracked_command_assets_in_project_scope() {
+        let _guard = cwd_lock().lock().expect("lock cwd");
+        let original_cwd = std::env::current_dir().expect("current dir");
+
+        let project_root = temp_dir("kasetto-clean-commands");
+        let command_dir = project_root.join(".opencode/commands");
+        let command_file = command_dir.join("review.md");
+        fs::create_dir_all(&command_dir).expect("create command dir");
+        fs::write(&command_file, "---\n---\nReview\n").expect("write command file");
+
+        let mut lock = LockFile::default();
+        lock.save_tracked_asset(
+            "command",
+            "command::local::review",
+            "review.md",
+            "h1",
+            "local",
+            &command_file.to_string_lossy(),
+        );
+        save_lock(&lock, Scope::Project, &project_root).expect("save lock");
+
+        std::env::set_current_dir(&project_root).expect("set current dir");
+        run(false, false, true, true, Some(Scope::Project)).expect("clean run");
+        std::env::set_current_dir(original_cwd).expect("restore current dir");
+
+        assert!(!command_file.exists());
+        let cleaned = load_lock(Scope::Project, &project_root).expect("load cleaned lock");
+        assert!(cleaned.assets.is_empty());
+
+        let _ = fs::remove_dir_all(&project_root);
+    }
 }

--- a/src/commands/sync/commands.rs
+++ b/src/commands/sync/commands.rs
@@ -1,0 +1,320 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::error::{err, Result};
+use crate::fsops::{hash_file, now_unix, resolve_path, select_command_targets, BrokenSkill};
+use crate::lock::LockFile;
+use crate::model::{Action, Summary};
+use crate::source::{discover_commands, materialize_source};
+use crate::ui::{eprint_fail, with_spinner};
+
+use super::{sync_label, SyncContext};
+
+pub(super) fn sync_commands(
+    ctx: &SyncContext,
+    lock: &mut LockFile,
+    destinations: &[PathBuf],
+    summary: &mut Summary,
+    actions: &mut Vec<Action>,
+) -> Result<()> {
+    if ctx.cfg.commands.is_empty() {
+        return Ok(());
+    }
+    if destinations.is_empty() {
+        return Err(err(
+            "commands are configured but none of the selected agents support commands",
+        ));
+    }
+
+    let mut desired_ids = HashSet::new();
+
+    for (i, src) in ctx.cfg.commands.iter().enumerate() {
+        let stage = std::env::temp_dir().join(format!("kasetto-cmd-{}-{}", now_unix(), i));
+        let source_spec = src.as_source_spec();
+        match materialize_source(&source_spec, ctx.cfg_dir, &stage) {
+            Ok(materialized) => {
+                let local_root = resolve_path(ctx.cfg_dir, &src.source);
+                let discovery_root = if src.source.contains("://") {
+                    stage.as_path()
+                } else {
+                    local_root.as_path()
+                };
+                let (targets, broken_commands) =
+                    select_command_targets(&src.commands, &discover_commands(discovery_root)?)?;
+                record_broken_commands(ctx, &src.source, broken_commands, summary, actions);
+
+                for (command_name, command_path) in targets {
+                    let label = sync_label("command", &command_name, &src.source, ctx.plain);
+                    with_spinner(ctx.animate, ctx.plain, &label, || {
+                        let id = format!("command::{}::{command_name}", src.source);
+                        desired_ids.insert(id.clone());
+
+                        let hash = hash_file(&command_path)?;
+                        let destination_paths: Vec<PathBuf> = destinations
+                            .iter()
+                            .map(|d| {
+                                let file_name = command_path
+                                    .file_name()
+                                    .map(|n| n.to_string_lossy().to_string())
+                                    .unwrap_or_else(|| format!("{command_name}.md"));
+                                d.join(file_name)
+                            })
+                            .collect();
+
+                        let unchanged = lock
+                            .get_tracked_asset("command", &id)
+                            .map(|(prev_hash, _)| {
+                                prev_hash == hash && destination_paths.iter().all(|p| p.exists())
+                            })
+                            .unwrap_or(false);
+
+                        if unchanged {
+                            summary.unchanged += 1;
+                            actions.push(Action {
+                                source: Some(src.source.clone()),
+                                skill: Some(format!("command:{command_name}")),
+                                status: "unchanged".into(),
+                                error: None,
+                            });
+                            return Ok(());
+                        }
+
+                        if ctx.dry_run {
+                            let status = if lock.get_tracked_asset("command", &id).is_some() {
+                                summary.updated += 1;
+                                "would_update"
+                            } else {
+                                summary.installed += 1;
+                                "would_install"
+                            };
+                            actions.push(Action {
+                                source: Some(src.source.clone()),
+                                skill: Some(format!("command:{command_name}")),
+                                status: status.into(),
+                                error: None,
+                            });
+                            return Ok(());
+                        }
+
+                        for destination in &destination_paths {
+                            if let Some(parent) = destination.parent() {
+                                fs::create_dir_all(parent)?;
+                            }
+                            fs::copy(&command_path, destination)?;
+                        }
+
+                        let status = if lock.get_tracked_asset("command", &id).is_some() {
+                            summary.updated += 1;
+                            "updated"
+                        } else {
+                            summary.installed += 1;
+                            "installed"
+                        };
+
+                        let destination_csv = destination_paths
+                            .iter()
+                            .map(|p| p.to_string_lossy().to_string())
+                            .collect::<Vec<_>>()
+                            .join(",");
+
+                        lock.save_tracked_asset(
+                            "command",
+                            &id,
+                            &command_path
+                                .file_name()
+                                .map(|n| n.to_string_lossy().to_string())
+                                .unwrap_or_else(|| format!("{command_name}.md")),
+                            &hash,
+                            &src.source,
+                            &destination_csv,
+                        );
+
+                        actions.push(Action {
+                            source: Some(src.source.clone()),
+                            skill: Some(format!("command:{command_name}")),
+                            status: status.into(),
+                            error: None,
+                        });
+                        Ok(())
+                    })?;
+                }
+                if let Some(cleanup_dir) = materialized.cleanup_dir {
+                    let _ = fs::remove_dir_all(cleanup_dir);
+                }
+            }
+            Err(e) => {
+                summary.failed += 1;
+                actions.push(Action {
+                    source: Some(src.source.clone()),
+                    skill: None,
+                    status: "source_error".into(),
+                    error: Some(e.to_string()),
+                });
+            }
+        }
+    }
+
+    remove_stale_commands(ctx, lock, &desired_ids, summary, actions);
+    Ok(())
+}
+
+fn record_broken_commands(
+    ctx: &SyncContext,
+    source: &str,
+    broken_commands: Vec<BrokenSkill>,
+    summary: &mut Summary,
+    actions: &mut Vec<Action>,
+) {
+    for broken in broken_commands {
+        summary.broken += 1;
+        actions.push(Action {
+            source: Some(source.to_string()),
+            skill: Some(format!("command:{}", broken.name)),
+            status: "broken".into(),
+            error: Some(broken.reason.clone()),
+        });
+        if !ctx.as_json && !ctx.quiet {
+            eprint_fail(&format!("command:{}", broken.name), source, ctx.plain);
+        }
+    }
+}
+
+fn remove_stale_commands(
+    ctx: &SyncContext,
+    lock: &mut LockFile,
+    desired_ids: &HashSet<String>,
+    summary: &mut Summary,
+    actions: &mut Vec<Action>,
+) {
+    let existing: Vec<(String, String)> = lock
+        .list_tracked_asset_ids("command")
+        .iter()
+        .map(|(id, dest)| ((*id).to_string(), (*dest).to_string()))
+        .collect();
+
+    for (id, destinations_csv) in existing {
+        if desired_ids.contains(&id) {
+            continue;
+        }
+
+        let command_name = id
+            .split("::")
+            .last()
+            .map(|n| format!("command:{n}"))
+            .unwrap_or_else(|| "command:-".to_string());
+
+        if ctx.dry_run {
+            summary.removed += 1;
+            actions.push(Action {
+                source: None,
+                skill: Some(command_name),
+                status: "would_remove".into(),
+                error: None,
+            });
+            continue;
+        }
+
+        for destination in destinations_csv.split(',').filter(|s| !s.is_empty()) {
+            let _ = fs::remove_file(destination);
+        }
+        lock.remove_tracked_asset(&id);
+        summary.removed += 1;
+        actions.push(Action {
+            source: None,
+            skill: Some(command_name),
+            status: "removed".into(),
+            error: None,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fsops::temp_dir;
+    use crate::model::{Config, Scope};
+
+    #[test]
+    fn sync_commands_installs_and_tracks_markdown_command() {
+        let root = temp_dir("kasetto-sync-command-md");
+        let source_root = root.join("source");
+        let command_dir = source_root.join("commands");
+        let destination = root.join("dest/.opencode/commands");
+        fs::create_dir_all(&command_dir).expect("create command dir");
+        fs::write(command_dir.join("review.md"), "---\n---\nReview\n").expect("write command");
+
+        let cfg: Config = serde_yaml::from_str(
+            "skills: []\ncommands:\n  - source: source\n    commands:\n      - review\n",
+        )
+        .expect("parse config");
+
+        let mut lock = LockFile::default();
+        let mut summary = Summary::default();
+        let mut actions = Vec::new();
+        let destinations = vec![destination.clone()];
+        let ctx = SyncContext {
+            cfg: &cfg,
+            cfg_dir: &root,
+            destinations: &[],
+            scope: Scope::Project,
+            dry_run: false,
+            yes: true,
+            animate: false,
+            plain: true,
+            as_json: false,
+            quiet: true,
+        };
+
+        sync_commands(&ctx, &mut lock, &destinations, &mut summary, &mut actions).expect("sync");
+
+        assert!(destination.join("review.md").exists());
+        assert_eq!(summary.installed, 1);
+        assert!(
+            lock.get_tracked_asset("command", "command::source::review")
+                .is_some()
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn sync_commands_preserves_toml_extension_for_gemini_style_commands() {
+        let root = temp_dir("kasetto-sync-command-toml");
+        let source_root = root.join("source");
+        let command_dir = source_root.join(".gemini/commands");
+        let destination = root.join("dest/.gemini/commands");
+        fs::create_dir_all(&command_dir).expect("create command dir");
+        fs::write(command_dir.join("triage.toml"), "name='triage'\n").expect("write command");
+
+        let cfg: Config = serde_yaml::from_str(
+            "skills: []\ncommands:\n  - source: source\n    commands:\n      - triage\n",
+        )
+        .expect("parse config");
+
+        let mut lock = LockFile::default();
+        let mut summary = Summary::default();
+        let mut actions = Vec::new();
+        let destinations = vec![destination.clone()];
+        let ctx = SyncContext {
+            cfg: &cfg,
+            cfg_dir: &root,
+            destinations: &[],
+            scope: Scope::Project,
+            dry_run: false,
+            yes: true,
+            animate: false,
+            plain: true,
+            as_json: false,
+            quiet: true,
+        };
+
+        sync_commands(&ctx, &mut lock, &destinations, &mut summary, &mut actions).expect("sync");
+
+        assert!(destination.join("triage.toml").exists());
+        assert!(!destination.join("triage.md").exists());
+        assert_eq!(summary.installed, 1);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+}

--- a/src/commands/sync/mod.rs
+++ b/src/commands/sync/mod.rs
@@ -1,3 +1,4 @@
+mod commands;
 mod mcps;
 mod skills;
 
@@ -7,7 +8,9 @@ use std::path::{Path, PathBuf};
 use crate::banner::print_banner_or_plain;
 use crate::colors::{ACCENT, ATTENTION, ERROR, INFO, RESET, SECONDARY, SUCCESS, WARNING};
 use crate::error::Result;
-use crate::fsops::{load_config_any, now_iso, now_unix, resolve_destinations};
+use crate::fsops::{
+    load_config_any, now_iso, now_unix, resolve_command_destinations, resolve_destinations,
+};
 use crate::lock::{load_lock, save_lock};
 use crate::model::{resolve_scope, Config, Report, Scope, Summary};
 use crate::ui::{animations_enabled, print_json, status_chip};
@@ -51,9 +54,13 @@ pub(crate) fn run(opts: &SyncOptions) -> Result<()> {
     let (cfg, cfg_dir, cfg_label) = load_config_any(opts.config_path)?;
     let scope = resolve_scope(opts.scope_override, Some(&cfg));
     let destinations = resolve_destinations(&cfg_dir, &cfg, scope)?;
+    let command_destinations = resolve_command_destinations(&cfg, scope, &cfg_dir)?;
     let destination = destinations[0].clone();
     if !opts.dry_run {
         for d in &destinations {
+            fs::create_dir_all(d)?;
+        }
+        for d in &command_destinations {
             fs::create_dir_all(d)?;
         }
     }
@@ -77,6 +84,13 @@ pub(crate) fn run(opts: &SyncOptions) -> Result<()> {
     let mut actions = Vec::new();
 
     skills::sync_skills(&ctx, &mut state, &mut summary, &mut actions)?;
+    commands::sync_commands(
+        &ctx,
+        &mut lock,
+        &command_destinations,
+        &mut summary,
+        &mut actions,
+    )?;
     mcps::sync_mcps(&ctx, &mut lock, &mut summary, &mut actions)?;
 
     if !opts.dry_run {

--- a/src/fsops/mod.rs
+++ b/src/fsops/mod.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::{err, Result};
-use crate::model::{Config, Scope, SkillTarget, SkillsField};
+use crate::model::{CommandTarget, CommandsField, Config, Scope, SkillTarget, SkillsField};
 use crate::source::{
     auth_env_inline_help, auth_for_request_url, http_fetch_auth_hint, rewrite_gitlab_raw_url,
 };
@@ -117,6 +117,63 @@ pub(crate) fn select_targets(
     Ok((out, broken))
 }
 
+pub(crate) type CommandSelection = (Vec<(String, PathBuf)>, Vec<BrokenSkill>);
+
+pub(crate) fn select_command_targets(
+    cf: &CommandsField,
+    available: &HashMap<String, PathBuf>,
+) -> Result<CommandSelection> {
+    let mut out = Vec::new();
+    let mut broken = Vec::new();
+    match cf {
+        CommandsField::Wildcard(s) if s == "*" => {
+            for (k, v) in available {
+                out.push((k.clone(), v.clone()));
+            }
+        }
+        CommandsField::List(items) => {
+            for it in items {
+                match it {
+                    CommandTarget::Name(name) => {
+                        if let Some(p) = available.get(name) {
+                            out.push((name.clone(), p.clone()));
+                        } else {
+                            broken.push(BrokenSkill {
+                                name: name.clone(),
+                                reason: format!("command not found: {name}"),
+                            });
+                        }
+                    }
+                    CommandTarget::Obj { name, path } => {
+                        if let Some(path) = path {
+                            let md = PathBuf::from(path).join(format!("{name}.md"));
+                            let toml = PathBuf::from(path).join(format!("{name}.toml"));
+                            if md.is_file() {
+                                out.push((name.clone(), md));
+                                continue;
+                            }
+                            if toml.is_file() {
+                                out.push((name.clone(), toml));
+                                continue;
+                            }
+                        }
+                        if let Some(p) = available.get(name) {
+                            out.push((name.clone(), p.clone()));
+                        } else {
+                            broken.push(BrokenSkill {
+                                name: name.clone(),
+                                reason: format!("command not found: {name}"),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        _ => return Err(err("invalid commands field")),
+    }
+    Ok((out, broken))
+}
+
 #[derive(Debug)]
 pub(crate) struct BrokenSkill {
     pub name: String,
@@ -203,6 +260,41 @@ pub(crate) fn resolve_mcp_settings_targets(
     Ok(out)
 }
 
+pub(crate) fn resolve_command_destinations(
+    cfg: &Config,
+    scope: Scope,
+    project_root: &Path,
+) -> Result<Vec<PathBuf>> {
+    let agents = cfg.agents();
+    if agents.is_empty() {
+        return Ok(vec![]);
+    }
+    let mut seen = std::collections::HashSet::<PathBuf>::new();
+    let mut out = Vec::new();
+    match scope {
+        Scope::Project => {
+            for a in agents {
+                if let Some(path) = a.command_project_path(project_root) {
+                    if seen.insert(path.clone()) {
+                        out.push(path);
+                    }
+                }
+            }
+        }
+        Scope::Global => {
+            let home = dirs_home()?;
+            for a in agents {
+                if let Some(path) = a.command_global_path(&home) {
+                    if seen.insert(path.clone()) {
+                        out.push(path);
+                    }
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
 pub(crate) fn now_unix() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -226,7 +318,10 @@ pub(crate) fn temp_dir(prefix: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{Agent, AgentField, Config, GitPin, SkillTarget, SkillsField};
+    use crate::model::{
+        Agent, AgentField, CommandTarget, CommandsField, Config, GitPin, SkillTarget,
+        SkillsField,
+    };
     use std::path::Path;
 
     #[test]
@@ -271,6 +366,68 @@ mod tests {
         assert_eq!(targets[0].1, skill_dir);
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn select_command_targets_supports_md_and_toml_overrides() {
+        let root = temp_dir("kasetto-command-targets");
+        let md_dir = root.join("md");
+        let toml_dir = root.join("toml");
+        fs::create_dir_all(&md_dir).expect("create md dir");
+        fs::create_dir_all(&toml_dir).expect("create toml dir");
+        fs::write(md_dir.join("review.md"), "# review\n").expect("write md");
+        fs::write(toml_dir.join("triage.toml"), "name='triage'\n").expect("write toml");
+
+        let mut available = HashMap::new();
+        available.insert("review".to_string(), PathBuf::from("/tmp/review.md"));
+        available.insert("triage".to_string(), PathBuf::from("/tmp/triage.toml"));
+
+        let cf = CommandsField::List(vec![
+            CommandTarget::Obj {
+                name: "review".to_string(),
+                path: Some(md_dir.to_string_lossy().to_string()),
+            },
+            CommandTarget::Obj {
+                name: "triage".to_string(),
+                path: Some(toml_dir.to_string_lossy().to_string()),
+            },
+        ]);
+
+        let (targets, broken) = select_command_targets(&cf, &available).expect("select commands");
+        assert!(broken.is_empty());
+        assert_eq!(targets.len(), 2);
+        assert!(targets.iter().any(|(n, p)| n == "review" && p.ends_with("review.md")));
+        assert!(targets.iter().any(|(n, p)| n == "triage" && p.ends_with("triage.toml")));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn resolve_command_destinations_for_supported_agents() {
+        let project_root = temp_dir("kasetto-command-destinations");
+        fs::create_dir_all(&project_root).expect("create project root");
+        let cfg: Config = serde_yaml::from_str(
+            "agent:\n  - claude-code\n  - opencode\n  - gemini-cli\nskills: []\n",
+        )
+        .expect("parse config");
+
+        let project_targets =
+            resolve_command_destinations(&cfg, Scope::Project, &project_root).expect("project");
+        assert!(project_targets.iter().any(|p| p.ends_with(".claude/commands")));
+        assert!(project_targets.iter().any(|p| p.ends_with(".opencode/commands")));
+        assert!(project_targets.iter().any(|p| p.ends_with(".gemini/commands")));
+
+        let global_targets =
+            resolve_command_destinations(&cfg, Scope::Global, &project_root).expect("global");
+        assert!(global_targets.iter().any(|p| p.ends_with(".claude/commands")));
+        assert!(
+            global_targets
+                .iter()
+                .any(|p| p.ends_with(".config/opencode/commands"))
+        );
+        assert!(global_targets.iter().any(|p| p.ends_with(".gemini/commands")));
+
+        let _ = fs::remove_dir_all(&project_root);
     }
 
     #[test]

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -130,6 +130,32 @@ fn mcp_servers_target(base: &Path, rel: &str) -> McpSettingsTarget {
 }
 
 impl Agent {
+    pub(crate) fn command_global_path(self, home: &Path) -> Option<PathBuf> {
+        match self {
+            Agent::Augment => Some(home.join(".augment/commands")),
+            Agent::ClaudeCode => Some(home.join(".claude/commands")),
+            Agent::GeminiCli => Some(home.join(".gemini/commands")),
+            Agent::Junie => Some(home.join(".junie/commands")),
+            Agent::OpenCode => Some(home.join(".config/opencode/commands")),
+            Agent::Roo => Some(home.join(".roo/commands")),
+            Agent::Windsurf => Some(home.join(".windsurf/workflows")),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn command_project_path(self, project_root: &Path) -> Option<PathBuf> {
+        match self {
+            Agent::Augment => Some(project_root.join(".augment/commands")),
+            Agent::ClaudeCode => Some(project_root.join(".claude/commands")),
+            Agent::GeminiCli => Some(project_root.join(".gemini/commands")),
+            Agent::Junie => Some(project_root.join(".junie/commands")),
+            Agent::OpenCode => Some(project_root.join(".opencode/commands")),
+            Agent::Roo => Some(project_root.join(".roo/commands")),
+            Agent::Windsurf => Some(project_root.join(".windsurf/workflows")),
+            _ => None,
+        }
+    }
+
     pub(crate) fn global_path(self, home: &Path) -> PathBuf {
         match self {
             Agent::Amp | Agent::Replit => home.join(".config/agents/skills"),

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -22,6 +22,8 @@ pub(crate) struct Config {
     pub skills: Vec<SourceSpec>,
     #[serde(default)]
     pub mcps: Vec<McpSourceSpec>,
+    #[serde(default)]
+    pub commands: Vec<CommandSourceSpec>,
 }
 
 impl Config {
@@ -114,6 +116,26 @@ pub(crate) struct McpSourceSpec {
     pub path: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub(crate) struct CommandSourceSpec {
+    pub source: String,
+    pub branch: Option<String>,
+    #[serde(rename = "ref")]
+    pub git_ref: Option<String>,
+    pub commands: CommandsField,
+}
+
+impl CommandSourceSpec {
+    pub(crate) fn as_source_spec(&self) -> SourceSpec {
+        SourceSpec {
+            source: self.source.clone(),
+            branch: self.branch.clone(),
+            git_ref: self.git_ref.clone(),
+            skills: SkillsField::Wildcard("*".to_string()),
+        }
+    }
+}
+
 impl McpSourceSpec {
     pub(crate) fn as_source_spec(&self) -> SourceSpec {
         SourceSpec {
@@ -135,6 +157,20 @@ pub(crate) enum SkillsField {
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub(crate) enum SkillTarget {
+    Name(String),
+    Obj { name: String, path: Option<String> },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum CommandsField {
+    Wildcard(String),
+    List(Vec<CommandTarget>),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum CommandTarget {
     Name(String),
     Obj { name: String, path: Option<String> },
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -6,7 +6,8 @@ use std::path::PathBuf;
 
 pub(crate) use agent::{all_mcp_project_targets, all_mcp_settings_targets, Agent, AgentField};
 pub(crate) use config::{
-    resolve_scope, Config, GitPin, Scope, SkillTarget, SkillsField, SourceSpec,
+    resolve_scope, CommandTarget, CommandsField, Config, GitPin, Scope, SkillTarget,
+    SkillsField, SourceSpec,
 };
 pub(crate) use types::{Action, InstalledSkill, Report, SkillEntry, State, Summary, SyncFailure};
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -123,6 +123,43 @@ pub(crate) fn discover_mcps(root: &Path) -> Result<Vec<PathBuf>> {
     Ok(out)
 }
 
+pub(crate) fn discover_commands(root: &Path) -> Result<HashMap<String, PathBuf>> {
+    let mut out = HashMap::new();
+    discover_commands_in_subdir(&root.join("commands"), &mut out)?;
+    discover_commands_in_subdir(&root.join("workflows"), &mut out)?;
+    discover_commands_in_subdir(&root.join(".claude/commands"), &mut out)?;
+    discover_commands_in_subdir(&root.join(".augment/commands"), &mut out)?;
+    discover_commands_in_subdir(&root.join(".gemini/commands"), &mut out)?;
+    discover_commands_in_subdir(&root.join(".junie/commands"), &mut out)?;
+    discover_commands_in_subdir(&root.join(".roo/commands"), &mut out)?;
+    discover_commands_in_subdir(&root.join(".windsurf/workflows"), &mut out)?;
+    discover_commands_in_subdir(&root.join(".opencode/commands"), &mut out)?;
+    Ok(out)
+}
+
+fn discover_commands_in_subdir(base: &Path, out: &mut HashMap<String, PathBuf>) -> Result<()> {
+    if !base.exists() {
+        return Ok(());
+    }
+    for e in fs::read_dir(base)? {
+        let e = e?;
+        if !e.file_type()?.is_file() {
+            continue;
+        }
+        let p = e.path();
+        let is_supported = p
+            .extension()
+            .map(|ext| ext == "md" || ext == "toml")
+            .unwrap_or(false);
+        if is_supported {
+            if let Some(stem) = p.file_stem() {
+                out.insert(stem.to_string_lossy().to_string(), p);
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Resolve a single MCP file by explicit path within a repo root.
 pub(crate) fn resolve_mcp_path(root: &Path, rel_path: &str) -> Result<Vec<PathBuf>> {
     let target = root.join(rel_path);
@@ -284,6 +321,45 @@ mod tests {
 
         let result = resolve_mcp_path(&root, "nonexistent.json");
         assert!(result.is_err());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn discover_commands_finds_markdown_and_toml_variants() {
+        let root = temp_dir("kasetto-cmd-discover");
+        fs::create_dir_all(root.join("commands")).unwrap();
+        fs::create_dir_all(root.join(".gemini/commands")).unwrap();
+        fs::create_dir_all(root.join(".windsurf/workflows")).unwrap();
+
+        fs::write(root.join("commands/review.md"), "# Review\n").unwrap();
+        fs::write(root.join(".gemini/commands/triage.toml"), "name='triage'\n").unwrap();
+        fs::write(
+            root.join(".windsurf/workflows/polish.md"),
+            "# Polish\n",
+        )
+        .unwrap();
+
+        let commands = discover_commands(&root).unwrap();
+        assert!(commands.contains_key("review"));
+        assert!(commands.contains_key("triage"));
+        assert!(commands.contains_key("polish"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn discover_commands_prefers_later_discovery_paths() {
+        let root = temp_dir("kasetto-cmd-precedence");
+        fs::create_dir_all(root.join("commands")).unwrap();
+        fs::create_dir_all(root.join(".opencode/commands")).unwrap();
+
+        fs::write(root.join("commands/dup.md"), "# first\n").unwrap();
+        fs::write(root.join(".opencode/commands/dup.md"), "# second\n").unwrap();
+
+        let commands = discover_commands(&root).unwrap();
+        let picked = commands.get("dup").expect("dup discovered");
+        assert!(picked.ends_with(".opencode/commands/dup.md"));
 
         let _ = fs::remove_dir_all(&root);
     }


### PR DESCRIPTION
## Summary
- add first-class `commands` config support and a new sync stage that discovers command/workflow files, selects targets, syncs changes, and tracks command assets in lock state
- add command destination resolution for supported agents (`augment`, `claude-code`, `gemini-cli`, `junie`, `roo`, `windsurf`, `opencode`) across project and global scopes, preserving source file extensions (`.md`/`.toml`)
- extend clean handling, docs, and examples for command assets, and add focused plus integration-style tests covering discovery, selection, sync install/update/remove behavior, and cleanup

## Testing
- cargo test