### PR TITLE
fix(github): use API endpoint for private repo archive downloads

### DIFF
--- a/src/source/remote.rs
+++ b/src/source/remote.rs
@@ -15,10 +15,17 @@ pub(super) fn remote_repo_archive_branch(
     branch: &str,
 ) -> (String, UrlRequestAuth) {
     match parsed {
-        RepoUrl::GitHub { host, owner, repo } => (
-            format!("https://{host}/{owner}/{repo}/archive/refs/heads/{branch}.tar.gz"),
-            UrlRequestAuth::for_github_archive(),
-        ),
+        RepoUrl::GitHub { host, owner, repo } => {
+            let auth = UrlRequestAuth::for_github_archive();
+            // GitHub's web archive endpoint doesn't support token auth for private repos.
+            // The API endpoint (api.github.com) does and works for public repos too.
+            let url = if host == "github.com" && !auth.headers.is_empty() {
+                format!("https://api.{host}/repos/{owner}/{repo}/tarball/{branch}")
+            } else {
+                format!("https://{host}/{owner}/{repo}/archive/refs/heads/{branch}.tar.gz")
+            };
+            (url, auth)
+        }
         _ => remote_repo_archive_ref(parsed, branch),
     }
 }
@@ -27,10 +34,15 @@ pub(super) fn remote_repo_archive_branch(
 /// Uses the short form that works for any ref type on all hosts.
 pub(super) fn remote_repo_archive_ref(parsed: &RepoUrl, git_ref: &str) -> (String, UrlRequestAuth) {
     match parsed {
-        RepoUrl::GitHub { host, owner, repo } => (
-            format!("https://{host}/{owner}/{repo}/archive/{git_ref}.tar.gz"),
-            UrlRequestAuth::for_github_archive(),
-        ),
+        RepoUrl::GitHub { host, owner, repo } => {
+            let auth = UrlRequestAuth::for_github_archive();
+            let url = if host == "github.com" && !auth.headers.is_empty() {
+                format!("https://api.{host}/repos/{owner}/{repo}/tarball/{git_ref}")
+            } else {
+                format!("https://{host}/{owner}/{repo}/archive/{git_ref}.tar.gz")
+            };
+            (url, auth)
+        }
         RepoUrl::GitLab { host, project_path } => (
             gitlab_project_archive_url(host, project_path, git_ref),
             UrlRequestAuth::for_gitlab_archive(),

--- a/src/source/remote.rs
+++ b/src/source/remote.rs
@@ -20,7 +20,7 @@ pub(super) fn remote_repo_archive_branch(
             // GitHub's web archive endpoint doesn't support token auth for private repos.
             // The API endpoint (api.github.com) does and works for public repos too.
             let url = if host == "github.com" && !auth.headers.is_empty() {
-                format!("https://api.{host}/repos/{owner}/{repo}/tarball/{branch}")
+                format!("https://api.{host}/repos/{owner}/{repo}/tarball/{}", encode_github_ref(branch))
             } else {
                 format!("https://{host}/{owner}/{repo}/archive/refs/heads/{branch}.tar.gz")
             };
@@ -37,7 +37,7 @@ pub(super) fn remote_repo_archive_ref(parsed: &RepoUrl, git_ref: &str) -> (Strin
         RepoUrl::GitHub { host, owner, repo } => {
             let auth = UrlRequestAuth::for_github_archive();
             let url = if host == "github.com" && !auth.headers.is_empty() {
-                format!("https://api.{host}/repos/{owner}/{repo}/tarball/{git_ref}")
+                format!("https://api.{host}/repos/{owner}/{repo}/tarball/{}", encode_github_ref(git_ref))
             } else {
                 format!("https://{host}/{owner}/{repo}/archive/{git_ref}.tar.gz")
             };
@@ -64,6 +64,12 @@ pub(super) fn remote_repo_archive_ref(parsed: &RepoUrl, git_ref: &str) -> (Strin
 /// GitLab API path encoding: `/` → `%2F`.
 fn encode_gitlab_path(path: &str) -> String {
     path.replace('/', "%2F")
+}
+
+/// GitHub API ref encoding: `/` → `%2F` so that refs like `feature/foo`
+/// are treated as a single path segment in the tarball URL.
+fn encode_github_ref(git_ref: &str) -> String {
+    git_ref.replace('/', "%2F")
 }
 
 fn gitlab_project_archive_url(host: &str, project_path: &str, branch: &str) -> String {
@@ -261,18 +267,45 @@ mod tests {
     use super::*;
 
     #[test]
-    fn github_branch_archive_uses_refs_heads_prefix() {
+    fn github_branch_archive_uses_refs_heads_prefix_without_token() {
+        let parsed = RepoUrl::GitHub {
+            host: "github.com".into(),
+            owner: "o".into(),
+            repo: "r".into(),
+        };
+        // No token set → falls back to web archive URL.
+        let (url, _) = remote_repo_archive_branch(&parsed, "main");
+        assert_eq!(url, "https://github.com/o/r/archive/refs/heads/main.tar.gz");
+    }
+
+    #[test]
+    fn github_branch_archive_uses_api_endpoint_with_token() {
+        std::env::set_var("GITHUB_TOKEN", "test-token");
         let parsed = RepoUrl::GitHub {
             host: "github.com".into(),
             owner: "o".into(),
             repo: "r".into(),
         };
         let (url, _) = remote_repo_archive_branch(&parsed, "main");
-        assert_eq!(url, "https://github.com/o/r/archive/refs/heads/main.tar.gz");
+        std::env::remove_var("GITHUB_TOKEN");
+        assert_eq!(url, "https://api.github.com/repos/o/r/tarball/main");
     }
 
     #[test]
-    fn github_ref_archive_uses_short_form() {
+    fn github_branch_archive_encodes_slash_in_ref_with_token() {
+        std::env::set_var("GITHUB_TOKEN", "test-token");
+        let parsed = RepoUrl::GitHub {
+            host: "github.com".into(),
+            owner: "o".into(),
+            repo: "r".into(),
+        };
+        let (url, _) = remote_repo_archive_branch(&parsed, "feature/foo");
+        std::env::remove_var("GITHUB_TOKEN");
+        assert_eq!(url, "https://api.github.com/repos/o/r/tarball/feature%2Ffoo");
+    }
+
+    #[test]
+    fn github_ref_archive_uses_short_form_without_token() {
         let parsed = RepoUrl::GitHub {
             host: "github.com".into(),
             owner: "o".into(),
@@ -282,6 +315,19 @@ mod tests {
         assert_eq!(url, "https://github.com/o/r/archive/v2.0.tar.gz");
         let (url, _) = remote_repo_archive_ref(&parsed, "abc123def");
         assert_eq!(url, "https://github.com/o/r/archive/abc123def.tar.gz");
+    }
+
+    #[test]
+    fn github_ref_archive_encodes_slash_in_ref_with_token() {
+        std::env::set_var("GITHUB_TOKEN", "test-token");
+        let parsed = RepoUrl::GitHub {
+            host: "github.com".into(),
+            owner: "o".into(),
+            repo: "r".into(),
+        };
+        let (url, _) = remote_repo_archive_ref(&parsed, "refs/tags/release/1.2");
+        std::env::remove_var("GITHUB_TOKEN");
+        assert_eq!(url, "https://api.github.com/repos/o/r/tarball/refs%2Ftags%2Frelease%2F1.2");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- GitHub's web archive endpoint (`github.com/{owner}/{repo}/archive/...`) ignores `Authorization: Bearer` tokens for private repos and returns 404
- The GitHub API endpoint (`api.github.com/repos/{owner}/{repo}/tarball/{branch}`) correctly honours tokens and works for public repos too (returns a 302 redirect that reqwest follows automatically)
- When `GITHUB_TOKEN` or `GH_TOKEN` is set and `host == "github.com"`, both `remote_repo_archive_branch` and `remote_repo_archive_ref` now use the API endpoint

## Test plan

- [ ] All 113 existing tests pass (`cargo test`)
- [ ] No URL change for repos without a token (public repos keep the existing web archive URL)
- [ ] No URL change for GitHub Enterprise hosts (only `github.com` is affected)
- [ ] Manual: `GITHUB_TOKEN=<token> kst sync --config <config-with-private-github-source>` now syncs skills from private repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)