### PR TITLE
feat(sync): add command source syncing across supported agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Kasetto is a **community-first** project that solves a different problem: **decl
 - **Declarative** — one YAML config describes your entire skill setup. Version it, share it, bootstrap a whole team in seconds. The config is the source of truth — readable, auditable, version-controlled.
 - **Enterprise & private repos** — GitHub, GitLab, Bitbucket, Codeberg, Gitea, and self-hosted instances out of the box. Onboard new engineers in one command. Everyone gets the exact same environment — zero drift, zero surprises.
 - **Multi-agent** — 21 built-in agent presets: Claude Code, Cursor, Codex, Windsurf, Copilot, Gemini CLI, and [many more](#supported-agents). One config, every agent updated.
-- **Skills & MCP** — any directory with a `SKILL.md` is a skill — no registry, no boilerplate. MCP server configs are auto-merged into every supported format (Cursor JSON, Claude JSON, Copilot VS Code, Codex TOML).
+- **Skills, MCPs & Commands** — any directory with a `SKILL.md` is a skill — no registry, no boilerplate. MCP server configs are auto-merged into every supported format (Cursor JSON, Claude JSON, Copilot VS Code, Codex TOML). Custom commands and workflows are copied to the right agent harness directory.
 - **Speed** — written in Rust. SHA-256 content hashing and lock file diffing mean only what changed gets touched. Full sync across all 21 agents finishes in seconds.
 - **Universal** — single static binary for macOS, Linux, and Windows. Install as `kasetto`, run as `kst`. CI-friendly with `--json` output and proper exit codes.
 
@@ -158,7 +158,7 @@ kst doctor [--json] [--quiet] [--plain] [--project | --global]
 
 ### `kst clean`
 
-Removes all tracked skills and MCP configs for the given scope.
+Removes all tracked skills, MCP configs, and command files for the given scope.
 
 ```bash
 kst clean [--dry-run] [--json] [--quiet] [--plain] [--project | --global]
@@ -166,7 +166,7 @@ kst clean [--dry-run] [--json] [--quiet] [--plain] [--project | --global]
 
 | Flag        | What it does                                               |
 | ----------- | ---------------------------------------------------------- |
-| `--dry-run` | Preview what would be removed (prints paths and MCP packs) |
+| `--dry-run` | Preview what would be removed (prints paths, command files, and MCP packs) |
 | `--json`    | Print output as JSON                                       |
 | `--quiet`   | Suppress non-error output                                  |
 | `--plain`   | Disable colors and banner-style header                     |
@@ -183,7 +183,7 @@ kst self update [--json]
 
 ### `kst self uninstall`
 
-Removes installed skills, MCP configs, Kasetto data, and the binary.
+Removes installed skills, command files, MCP configs, Kasetto data, and the binary.
 
 ```bash
 kst self uninstall [--yes]
@@ -260,6 +260,18 @@ mcps:
     mcps:
       - github        # → mcps/github.json
       - linear        # → mcps/linear.json
+
+  # Custom directory via { name, path }
+  - source: https://github.com/org/other
+    mcps:
+      - name: my-server
+        path: tools   # → tools/my-server.json
+
+# Commands (optional)
+commands:
+  - source: https://github.com/org/opencode-commands
+    commands:
+      - review-changes
 ```
 
 | Key                  | Required | Description                                                         |
@@ -278,6 +290,11 @@ mcps:
 | `mcps[].branch`      | no       | Branch for remote sources                                           |
 | `mcps[].ref`         | no       | Git tag, commit SHA, or ref                                         |
 | `mcps[].mcps`        | **yes**  | `"*"` to discover all, or a list of names / `{ name, path }` objects |
+| `commands`           | no       | List of command sources                                             |
+| `commands[].source`  | **yes**  | Git host URL or local path containing command files                 |
+| `commands[].branch`  | no       | Branch for remote sources                                           |
+| `commands[].ref`     | no       | Git tag, commit SHA, or ref                                         |
+| `commands[].commands` | **yes** | `"*"` for all, or a list of names / `{ name, path }` objects       |
 
 ## Supported Agents
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -38,3 +38,15 @@ destination: ~/.my-custom-agent/skills
 
 If both `agent` and `destination` are set, `destination` wins. See the
 [configuration reference](./configuration.md#agent-vs-destination) for details.
+
+## Command Support
+
+Kasetto can also sync custom command/workflow files (from the `commands:` config block) for:
+
+- `augment` -> `~/.augment/commands/` (`.augment/commands/` in project scope)
+- `claude-code` -> `~/.claude/commands/` (`.claude/commands/`)
+- `gemini-cli` -> `~/.gemini/commands/` (`.gemini/commands/`)
+- `junie` -> `~/.junie/commands/` (`.junie/commands/`)
+- `roo` -> `~/.roo/commands/` (`.roo/commands/`)
+- `windsurf` -> `~/.windsurf/workflows/` (`.windsurf/workflows/`)
+- `opencode` -> `~/.config/opencode/commands/` (`.opencode/commands/`)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-Kasetto can pull skills and MCP configs from private repositories. No login command or credentials file needed — just set an environment variable and it works.
+Kasetto can pull skills, commands, and MCP configs from private repositories. No login command or credentials file needed — just set an environment variable and it works.
 
 ## Supported Git Hosts
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,7 +17,7 @@ kst init [OPTIONS]
 
 ## `kst sync`
 
-Reads your config, fetches any remote skills, and brings your local install up to date.
+Reads your config, fetches any remote skills and commands, and brings your local install up to date.
 
 ```bash
 kst sync [OPTIONS]
@@ -90,7 +90,7 @@ kst doctor [OPTIONS]
 
 ## `kst clean`
 
-Removes everything Kasetto installed for the given scope — skills, MCP configs, and lock file entries.
+Removes everything Kasetto installed for the given scope — skills, command files, MCP configs, and lock file entries.
 
 ```bash
 kst clean [OPTIONS]
@@ -100,7 +100,7 @@ kst clean [OPTIONS]
 
 | Flag        | Description                                                     |
 | ----------- | --------------------------------------------------------------- |
-| `--dry-run` | Preview what would be removed (lists skill paths and MCP packs) |
+| `--dry-run` | Preview what would be removed (lists skill paths, command files, and MCP packs) |
 | `--json`    | Print output as JSON                                            |
 | `--quiet`   | Suppress non-error output                                       |
 | `--plain`   | Disable colors and banner-style header                          |
@@ -132,7 +132,7 @@ kst self update [OPTIONS]
 
 ### `kst self uninstall`
 
-A full teardown: removes installed skills and MCP configs, clears Kasetto's data directories, and deletes the binary.
+A full teardown: removes installed skills, command files, and MCP configs, clears Kasetto's data directories, and deletes the binary.
 
 ```bash
 kst self uninstall [OPTIONS]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,12 @@ mcps:
     mcps:
       - name: my-server
         path: tools   # → tools/my-server.json
+
+# OpenCode commands (optional)
+commands:
+  - source: https://github.com/org/opencode-commands
+    commands:
+      - review-changes
 ```
 
 ## Reference
@@ -80,6 +86,7 @@ mcps:
 | `scope`       | no       | `"global"` (default) or `"project"` - where to install              |
 | `skills`      | **yes**  | List of skill sources                                               |
 | `mcps`        | no       | List of MCP server sources                                          |
+| `commands`    | no       | List of OpenCode command sources                                    |
 
 ### Skill Source Fields
 
@@ -132,6 +139,43 @@ Each entry in the `mcps` list can be a plain string (name) or an object — mirr
 MCP config files must contain a `mcpServers` object with server definitions. Servers are merged
 into each agent's native settings file (e.g., `.claude.json` for Claude Code, `.cursor/mcp.json`
 for Cursor). See [how sync works](./how-sync-works.md) for merge behavior details.
+
+### Command Source Fields
+
+`commands` installs custom command/workflow files for supported harnesses.
+
+| Key        | Required | Description                                                            |
+| ---------- | -------- | ---------------------------------------------------------------------- |
+| `source`   | **yes**  | Git host URL or local path containing command files                    |
+| `branch`   | no       | Branch for remote sources (default: `main`, falls back to `master`)    |
+| `ref`      | no       | Git tag, commit SHA, or ref - takes priority over `branch`             |
+| `commands` | **yes**  | `"*"` for all, or a list of names / `{ name, path }` objects           |
+
+Kasetto discovers commands in these source locations:
+
+1. `commands/*.{md,toml}`
+2. `workflows/*.{md,toml}`
+3. `.claude/commands/*.{md,toml}`
+4. `.augment/commands/*.{md,toml}`
+5. `.gemini/commands/*.{md,toml}`
+6. `.junie/commands/*.{md,toml}`
+7. `.roo/commands/*.{md,toml}`
+8. `.windsurf/workflows/*.{md,toml}`
+9. `.opencode/commands/*.{md,toml}`
+
+Command names are derived from the file stem (`review-changes.md` or `review-changes.toml` -> `/review-changes`).
+
+Each command entry can be either:
+
+- a string command name (without `.md`)
+- an object with:
+  - `name` (required): command name
+  - `path` (optional): directory that contains `name.md`
+
+!!! note
+
+    Command sync currently writes to these harness directories when selected via `agent`:
+    `claude-code`, `augment`, `gemini-cli`, `junie`, `roo`, `windsurf`, and `opencode`.
 
 ## Remote Configs
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -102,3 +102,26 @@ mcps:
       - name: my-server
         path: tools   # → tools/my-server.json
 ```
+
+## Custom Commands
+
+Sync custom command files into supported agents:
+
+```yaml
+agent:
+  - claude-code
+  - opencode
+
+skills:
+  - source: https://github.com/acme/skills
+    skills: "*"
+
+commands:
+  - source: https://github.com/acme/opencode-commands
+    commands:
+      - review-changes
+      - name: deep-dive
+        path: workflows
+```
+
+Command files are discovered in conventional directories (`commands/`, `.claude/commands/`, `.opencode/commands/`, etc.) and copied into each selected agent's command directory. Use `commands: "*"` to install every command found in the source.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 # FAQ
 
-**When you need this:** You have a quick "what happens if…" question about syncing skills or MCP servers.
+**When you need this:** You have a quick "what happens if…" question about syncing skills, commands, or MCP servers.
 
 ## Will Kasetto Overwrite My MCP Entries?
 

--- a/docs/how-sync-works.md
+++ b/docs/how-sync-works.md
@@ -1,6 +1,6 @@
 # How Sync Works
 
-A look at what `kst sync` actually does — how skills are installed, how MCP configs are merged, what gets overwritten, and what's always left alone.
+A look at what `kst sync` actually does — how skills and commands are installed, how MCP configs are merged, what gets overwritten, and what's always left alone.
 
 ## Sync Flow
 
@@ -17,6 +17,11 @@ A look at what `kst sync` actually does — how skills are installed, how MCP co
    b. Discover MCP pack files in source
    c. For each pack: hash → compare to lock → merge into agent settings if changed
    d. Remove MCP entries no longer in config
+4. Sync commands
+   a. For each command source: materialize (download if remote)
+   b. Discover command files in source
+   c. For each command: hash → compare to lock → copy if changed
+   d. Remove command entries no longer in config
 5. Save lock file and report (unless --dry-run)
 ```
 
@@ -36,6 +41,18 @@ Skills are plain directories with a `SKILL.md` file (see [writing skills](./writ
 - **Removes** skill directories that are no longer listed in the config.
 
 Skills are fully replaced on update — no partial merges.
+
+## Commands: Copy and Replace
+
+Commands are individual `.md` or `.toml` files discovered in the source (see [configuration reference](./configuration.md#command-source-fields)). On each sync, Kasetto:
+
+- **Discovers** command files by scanning conventional directories (`commands/`, `workflows/`, `.claude/commands/`, etc.).
+- **Hashes** each command file.
+- **Compares** the hash to the lock file. If unchanged and the file still exists at every destination, the command is skipped.
+- **Copies** the file to each selected agent's command directory, replacing any previous version.
+- **Removes** command files that are no longer listed in the config.
+
+Commands are fully replaced on update — no partial merges.
 
 ## MCP Servers: Discovery and Additive Merge
 
@@ -99,6 +116,8 @@ The lock file is how Kasetto knows what to remove when you drop a source from th
 
 **Skills** are tracked by a composite key (`source::skill-name`) along with their destination path and hash.
 
+**Commands** are tracked as assets with the file name and a comma-separated list of destination paths (one per selected agent). Only these tracked files are removed during cleanup.
+
 **MCP servers** are tracked as assets with the server names they installed (e.g., `destination: "git-tools,airflow"`). Only these tracked names are removed during cleanup.
 
 !!! important
@@ -112,6 +131,7 @@ The lock file is how Kasetto knows what to remove when you drop a source from th
 Remove a source from `kasetto.yaml` and re-sync:
 
 - **Skills:** The skill directory is deleted from disk.
+- **Commands:** The specific command files that Kasetto installed are removed from every agent's command directory.
 - **MCPs:** The specific server entries that Kasetto installed are removed from the agent's settings
   file. The file itself is preserved.
 
@@ -120,6 +140,7 @@ Remove a source from `kasetto.yaml` and re-sync:
 Removes everything tracked in the lock file for the given scope:
 
 - Deletes all tracked skill directories
+- Removes all tracked command files from every agent's command directory
 - Removes all tracked MCP server entries from every agent's settings file
 - Clears the lock file
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,6 +119,25 @@ Kasetto merges them into each agent's native settings file during sync — nothi
 
 If you want the exact merge rules and conflict behavior, see [How Sync Works](./how-sync-works.md#mcp-servers-discovery-and-additive-merge).
 
+## Commands
+
+Kasetto can also sync custom command and workflow files for supported agents. Add a `commands` section to your config:
+
+```yaml
+agent: claude-code
+
+skills:
+  - source: https://github.com/org/skill-pack
+    skills: "*"
+
+commands:
+  - source: https://github.com/org/opencode-commands
+    commands:
+      - review-changes
+```
+
+Command files (`.md` or `.toml`) are copied into each supported agent's command directory during sync. See [configuration reference](./configuration.md#command-source-fields) for discovery paths and supported agents.
+
 ## Exploring What's Installed
 
 Want to see what's installed? Open the browser:

--- a/docs/security.md
+++ b/docs/security.md
@@ -13,13 +13,16 @@
 During `kst sync`, Kasetto may:
 
 - **Install/update skills** by copying skill directories into the chosen destination path
+- **Install/update commands** by copying command files into each supported agent's command directory
 - **Remove skills** that are no longer in your config (for the selected scope)
+- **Remove commands** that are no longer in your config (for the selected scope)
 - **Merge MCP servers** into agent-native settings files (additive merge; never overwrite existing servers)
 - **Write the lock file** for the selected scope
 
 Kasetto is designed around a "tracked-only" principle:
 
 - **Skills**: fully managed at their install paths for entries tracked in the lock
+- **Commands**: only command files that Kasetto installed (tracked in the lock) are removed during cleanup
 - **MCP servers**: only server entries that Kasetto installed (tracked in the lock) are removed during cleanup
 
 See [How Sync Works](./how-sync-works.md) for details.

--- a/kasetto.example.yaml
+++ b/kasetto.example.yaml
@@ -9,3 +9,8 @@ skills:
     skills:
       - name: pivoshenko-brand-guidelines
       - name: skill-creator
+
+commands:
+  - source: https://github.com/acme/opencode-commands
+    commands:
+      - review-changes

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -14,6 +14,7 @@ use crate::ui::{animations_enabled, print_json, SYM_OK};
 struct CleanOutput {
     skills_removed: usize,
     mcps_removed: usize,
+    commands_removed: usize,
     dry_run: bool,
 }
 
@@ -35,9 +36,11 @@ pub(crate) fn run(
 
     let state = lock.state();
     let mcp_assets = lock.list_tracked_asset_ids("mcp");
+    let command_assets = lock.list_tracked_asset_ids("command");
 
     let skills_count = state.skills.len();
     let mcps_count = mcp_assets.len();
+    let commands_count = command_assets.len();
 
     if !dry_run {
         for entry in state.skills.values() {
@@ -62,6 +65,12 @@ pub(crate) fn run(
             }
         }
 
+        for (_id, destination_csv) in &command_assets {
+            for destination in destination_csv.split(',').filter(|s| !s.is_empty()) {
+                let _ = fs::remove_file(destination);
+            }
+        }
+
         lock.clear_all();
         save_lock(&lock, scope, &project_root)?;
     }
@@ -69,6 +78,7 @@ pub(crate) fn run(
     let output = CleanOutput {
         skills_removed: skills_count,
         mcps_removed: mcps_count,
+        commands_removed: commands_count,
         dry_run,
     };
 
@@ -84,7 +94,7 @@ pub(crate) fn run(
         println!();
         println!(
             "  {label_color}{prefix}{RESET}: {}",
-            skills_count + mcps_count
+            skills_count + mcps_count + commands_count
         );
 
         if dry_run {
@@ -129,6 +139,31 @@ pub(crate) fn run(
                     }
                 }
             }
+
+            let command_files: Vec<_> = lock
+                .assets
+                .iter()
+                .filter(|(_, a)| a.kind == "command")
+                .collect();
+            if !command_files.is_empty() {
+                println!("  OpenCode commands:");
+                for (_, a) in command_files {
+                    let destinations: String = a
+                        .destination
+                        .split(',')
+                        .filter(|s| !s.is_empty())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    if color {
+                        println!(
+                            "    {ACCENT}command{RESET} {}  (source: {})",
+                            destinations, a.source
+                        );
+                    } else {
+                        println!("    command {}  (source: {})", destinations, a.source);
+                    }
+                }
+            }
         }
 
         if !dry_run {
@@ -141,4 +176,50 @@ pub(crate) fn run(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fsops::temp_dir;
+    use crate::lock::{load_lock, save_lock, LockFile};
+    use std::sync::{Mutex, OnceLock};
+
+    fn cwd_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn clean_removes_tracked_command_assets_in_project_scope() {
+        let _guard = cwd_lock().lock().expect("lock cwd");
+        let original_cwd = std::env::current_dir().expect("current dir");
+
+        let project_root = temp_dir("kasetto-clean-commands");
+        let command_dir = project_root.join(".opencode/commands");
+        let command_file = command_dir.join("review.md");
+        fs::create_dir_all(&command_dir).expect("create command dir");
+        fs::write(&command_file, "---\n---\nReview\n").expect("write command file");
+
+        let mut lock = LockFile::default();
+        lock.save_tracked_asset(
+            "command",
+            "command::local::review",
+            "review.md",
+            "h1",
+            "local",
+            &command_file.to_string_lossy(),
+        );
+        save_lock(&lock, Scope::Project, &project_root).expect("save lock");
+
+        std::env::set_current_dir(&project_root).expect("set current dir");
+        run(false, false, true, true, Some(Scope::Project)).expect("clean run");
+        std::env::set_current_dir(original_cwd).expect("restore current dir");
+
+        assert!(!command_file.exists());
+        let cleaned = load_lock(Scope::Project, &project_root).expect("load cleaned lock");
+        assert!(cleaned.assets.is_empty());
+
+        let _ = fs::remove_dir_all(&project_root);
+    }
 }

--- a/src/commands/sync/commands.rs
+++ b/src/commands/sync/commands.rs
@@ -1,0 +1,319 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::error::{err, Result};
+use crate::fsops::{hash_file, now_unix, resolve_path, select_command_targets, BrokenSkill};
+use crate::lock::LockFile;
+use crate::model::{Action, Summary};
+use crate::source::{discover_commands, materialize_source};
+use crate::ui::{eprint_fail, with_spinner};
+
+use super::{sync_label, SyncContext};
+
+pub(super) fn sync_commands(
+    ctx: &SyncContext,
+    lock: &mut LockFile,
+    destinations: &[PathBuf],
+    summary: &mut Summary,
+    actions: &mut Vec<Action>,
+) -> Result<()> {
+    if ctx.cfg.commands.is_empty() {
+        return Ok(());
+    }
+    if destinations.is_empty() {
+        return Err(err(
+            "commands are configured but none of the selected agents support commands",
+        ));
+    }
+
+    let mut desired_ids = HashSet::new();
+
+    for (i, src) in ctx.cfg.commands.iter().enumerate() {
+        let stage = std::env::temp_dir().join(format!("kasetto-cmd-{}-{}", now_unix(), i));
+        let source_spec = src.as_source_spec();
+        match materialize_source(&source_spec, ctx.cfg_dir, &stage) {
+            Ok(materialized) => {
+                let local_root = resolve_path(ctx.cfg_dir, &src.source);
+                let discovery_root = if src.source.contains("://") {
+                    stage.as_path()
+                } else {
+                    local_root.as_path()
+                };
+                let (targets, broken_commands) =
+                    select_command_targets(&src.commands, &discover_commands(discovery_root)?)?;
+                record_broken_commands(ctx, &src.source, broken_commands, summary, actions);
+
+                for (command_name, command_path) in targets {
+                    let label = sync_label("command", &command_name, &src.source, ctx.plain);
+                    with_spinner(ctx.animate, ctx.plain, &label, || {
+                        let id = format!("command::{}::{command_name}", src.source);
+                        desired_ids.insert(id.clone());
+
+                        let hash = hash_file(&command_path)?;
+                        let destination_paths: Vec<PathBuf> = destinations
+                            .iter()
+                            .map(|d| {
+                                let file_name = command_path
+                                    .file_name()
+                                    .map(|n| n.to_string_lossy().to_string())
+                                    .unwrap_or_else(|| format!("{command_name}.md"));
+                                d.join(file_name)
+                            })
+                            .collect();
+
+                        let unchanged = lock
+                            .get_tracked_asset("command", &id)
+                            .map(|(prev_hash, _)| {
+                                prev_hash == hash && destination_paths.iter().all(|p| p.exists())
+                            })
+                            .unwrap_or(false);
+
+                        if unchanged {
+                            summary.unchanged += 1;
+                            actions.push(Action {
+                                source: Some(src.source.clone()),
+                                skill: Some(format!("command:{command_name}")),
+                                status: "unchanged".into(),
+                                error: None,
+                            });
+                            return Ok(());
+                        }
+
+                        if ctx.dry_run {
+                            let status = if lock.get_tracked_asset("command", &id).is_some() {
+                                summary.updated += 1;
+                                "would_update"
+                            } else {
+                                summary.installed += 1;
+                                "would_install"
+                            };
+                            actions.push(Action {
+                                source: Some(src.source.clone()),
+                                skill: Some(format!("command:{command_name}")),
+                                status: status.into(),
+                                error: None,
+                            });
+                            return Ok(());
+                        }
+
+                        for destination in &destination_paths {
+                            if let Some(parent) = destination.parent() {
+                                fs::create_dir_all(parent)?;
+                            }
+                            fs::copy(&command_path, destination)?;
+                        }
+
+                        let status = if lock.get_tracked_asset("command", &id).is_some() {
+                            summary.updated += 1;
+                            "updated"
+                        } else {
+                            summary.installed += 1;
+                            "installed"
+                        };
+
+                        let destination_csv = destination_paths
+                            .iter()
+                            .map(|p| p.to_string_lossy().to_string())
+                            .collect::<Vec<_>>()
+                            .join(",");
+
+                        lock.save_tracked_asset(
+                            "command",
+                            &id,
+                            &command_path
+                                .file_name()
+                                .map(|n| n.to_string_lossy().to_string())
+                                .unwrap_or_else(|| format!("{command_name}.md")),
+                            &hash,
+                            &src.source,
+                            &destination_csv,
+                        );
+
+                        actions.push(Action {
+                            source: Some(src.source.clone()),
+                            skill: Some(format!("command:{command_name}")),
+                            status: status.into(),
+                            error: None,
+                        });
+                        Ok(())
+                    })?;
+                }
+                if let Some(cleanup_dir) = materialized.cleanup_dir {
+                    let _ = fs::remove_dir_all(cleanup_dir);
+                }
+            }
+            Err(e) => {
+                summary.failed += 1;
+                actions.push(Action {
+                    source: Some(src.source.clone()),
+                    skill: None,
+                    status: "source_error".into(),
+                    error: Some(e.to_string()),
+                });
+            }
+        }
+    }
+
+    remove_stale_commands(ctx, lock, &desired_ids, summary, actions);
+    Ok(())
+}
+
+fn record_broken_commands(
+    ctx: &SyncContext,
+    source: &str,
+    broken_commands: Vec<BrokenSkill>,
+    summary: &mut Summary,
+    actions: &mut Vec<Action>,
+) {
+    for broken in broken_commands {
+        summary.broken += 1;
+        actions.push(Action {
+            source: Some(source.to_string()),
+            skill: Some(format!("command:{}", broken.name)),
+            status: "broken".into(),
+            error: Some(broken.reason.clone()),
+        });
+        if !ctx.as_json && !ctx.quiet {
+            eprint_fail(&format!("command:{}", broken.name), source, ctx.plain);
+        }
+    }
+}
+
+fn remove_stale_commands(
+    ctx: &SyncContext,
+    lock: &mut LockFile,
+    desired_ids: &HashSet<String>,
+    summary: &mut Summary,
+    actions: &mut Vec<Action>,
+) {
+    let existing: Vec<(String, String)> = lock
+        .list_tracked_asset_ids("command")
+        .iter()
+        .map(|(id, dest)| ((*id).to_string(), (*dest).to_string()))
+        .collect();
+
+    for (id, destinations_csv) in existing {
+        if desired_ids.contains(&id) {
+            continue;
+        }
+
+        let command_name = id
+            .split("::")
+            .last()
+            .map(|n| format!("command:{n}"))
+            .unwrap_or_else(|| "command:-".to_string());
+
+        if ctx.dry_run {
+            summary.removed += 1;
+            actions.push(Action {
+                source: None,
+                skill: Some(command_name),
+                status: "would_remove".into(),
+                error: None,
+            });
+            continue;
+        }
+
+        for destination in destinations_csv.split(',').filter(|s| !s.is_empty()) {
+            let _ = fs::remove_file(destination);
+        }
+        lock.remove_tracked_asset(&id);
+        summary.removed += 1;
+        actions.push(Action {
+            source: None,
+            skill: Some(command_name),
+            status: "removed".into(),
+            error: None,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fsops::temp_dir;
+    use crate::model::{Config, Scope};
+
+    #[test]
+    fn sync_commands_installs_and_tracks_markdown_command() {
+        let root = temp_dir("kasetto-sync-command-md");
+        let source_root = root.join("source");
+        let command_dir = source_root.join("commands");
+        let destination = root.join("dest/.opencode/commands");
+        fs::create_dir_all(&command_dir).expect("create command dir");
+        fs::write(command_dir.join("review.md"), "---\n---\nReview\n").expect("write command");
+
+        let cfg: Config = serde_yaml::from_str(
+            "skills: []\ncommands:\n  - source: source\n    commands:\n      - review\n",
+        )
+        .expect("parse config");
+
+        let mut lock = LockFile::default();
+        let mut summary = Summary::default();
+        let mut actions = Vec::new();
+        let destinations = vec![destination.clone()];
+        let ctx = SyncContext {
+            cfg: &cfg,
+            cfg_dir: &root,
+            destinations: &[],
+            scope: Scope::Project,
+            dry_run: false,
+            yes: true,
+            animate: false,
+            plain: true,
+            as_json: false,
+            quiet: true,
+        };
+
+        sync_commands(&ctx, &mut lock, &destinations, &mut summary, &mut actions).expect("sync");
+
+        assert!(destination.join("review.md").exists());
+        assert_eq!(summary.installed, 1);
+        assert!(lock
+            .get_tracked_asset("command", "command::source::review")
+            .is_some());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn sync_commands_preserves_toml_extension_for_gemini_style_commands() {
+        let root = temp_dir("kasetto-sync-command-toml");
+        let source_root = root.join("source");
+        let command_dir = source_root.join(".gemini/commands");
+        let destination = root.join("dest/.gemini/commands");
+        fs::create_dir_all(&command_dir).expect("create command dir");
+        fs::write(command_dir.join("triage.toml"), "name='triage'\n").expect("write command");
+
+        let cfg: Config = serde_yaml::from_str(
+            "skills: []\ncommands:\n  - source: source\n    commands:\n      - triage\n",
+        )
+        .expect("parse config");
+
+        let mut lock = LockFile::default();
+        let mut summary = Summary::default();
+        let mut actions = Vec::new();
+        let destinations = vec![destination.clone()];
+        let ctx = SyncContext {
+            cfg: &cfg,
+            cfg_dir: &root,
+            destinations: &[],
+            scope: Scope::Project,
+            dry_run: false,
+            yes: true,
+            animate: false,
+            plain: true,
+            as_json: false,
+            quiet: true,
+        };
+
+        sync_commands(&ctx, &mut lock, &destinations, &mut summary, &mut actions).expect("sync");
+
+        assert!(destination.join("triage.toml").exists());
+        assert!(!destination.join("triage.md").exists());
+        assert_eq!(summary.installed, 1);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+}

--- a/src/commands/sync/mod.rs
+++ b/src/commands/sync/mod.rs
@@ -1,3 +1,4 @@
+mod commands;
 mod mcps;
 mod skills;
 
@@ -7,7 +8,9 @@ use std::path::{Path, PathBuf};
 use crate::banner::print_banner_or_plain;
 use crate::colors::{ACCENT, ATTENTION, ERROR, INFO, RESET, SECONDARY, SUCCESS, WARNING};
 use crate::error::Result;
-use crate::fsops::{load_config_any, now_iso, now_unix, resolve_destinations};
+use crate::fsops::{
+    load_config_any, now_iso, now_unix, resolve_command_destinations, resolve_destinations,
+};
 use crate::lock::{load_lock, save_lock};
 use crate::model::{resolve_scope, Config, Report, Scope, Summary};
 use crate::ui::{animations_enabled, print_json, status_chip};
@@ -51,9 +54,13 @@ pub(crate) fn run(opts: &SyncOptions) -> Result<()> {
     let (cfg, cfg_dir, cfg_label) = load_config_any(opts.config_path)?;
     let scope = resolve_scope(opts.scope_override, Some(&cfg));
     let destinations = resolve_destinations(&cfg_dir, &cfg, scope)?;
+    let command_destinations = resolve_command_destinations(&cfg, scope, &cfg_dir)?;
     let destination = destinations[0].clone();
     if !opts.dry_run {
         for d in &destinations {
+            fs::create_dir_all(d)?;
+        }
+        for d in &command_destinations {
             fs::create_dir_all(d)?;
         }
     }
@@ -77,6 +84,13 @@ pub(crate) fn run(opts: &SyncOptions) -> Result<()> {
     let mut actions = Vec::new();
 
     skills::sync_skills(&ctx, &mut state, &mut summary, &mut actions)?;
+    commands::sync_commands(
+        &ctx,
+        &mut lock,
+        &command_destinations,
+        &mut summary,
+        &mut actions,
+    )?;
     mcps::sync_mcps(&ctx, &mut lock, &mut summary, &mut actions)?;
 
     if !opts.dry_run {

--- a/src/fsops/mod.rs
+++ b/src/fsops/mod.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::{err, Result};
-use crate::model::{Config, Scope, SkillTarget, SkillsField};
+use crate::model::{CommandTarget, CommandsField, Config, Scope, SkillTarget, SkillsField};
 use crate::source::{
     auth_env_inline_help, auth_for_request_url, http_fetch_auth_hint, rewrite_browse_to_raw_url,
 };
@@ -122,6 +122,63 @@ pub(crate) fn select_targets(
     Ok((out, broken))
 }
 
+pub(crate) type CommandSelection = (Vec<(String, PathBuf)>, Vec<BrokenSkill>);
+
+pub(crate) fn select_command_targets(
+    cf: &CommandsField,
+    available: &HashMap<String, PathBuf>,
+) -> Result<CommandSelection> {
+    let mut out = Vec::new();
+    let mut broken = Vec::new();
+    match cf {
+        CommandsField::Wildcard(s) if s == "*" => {
+            for (k, v) in available {
+                out.push((k.clone(), v.clone()));
+            }
+        }
+        CommandsField::List(items) => {
+            for it in items {
+                match it {
+                    CommandTarget::Name(name) => {
+                        if let Some(p) = available.get(name) {
+                            out.push((name.clone(), p.clone()));
+                        } else {
+                            broken.push(BrokenSkill {
+                                name: name.clone(),
+                                reason: format!("command not found: {name}"),
+                            });
+                        }
+                    }
+                    CommandTarget::Obj { name, path } => {
+                        if let Some(path) = path {
+                            let md = PathBuf::from(path).join(format!("{name}.md"));
+                            let toml = PathBuf::from(path).join(format!("{name}.toml"));
+                            if md.is_file() {
+                                out.push((name.clone(), md));
+                                continue;
+                            }
+                            if toml.is_file() {
+                                out.push((name.clone(), toml));
+                                continue;
+                            }
+                        }
+                        if let Some(p) = available.get(name) {
+                            out.push((name.clone(), p.clone()));
+                        } else {
+                            broken.push(BrokenSkill {
+                                name: name.clone(),
+                                reason: format!("command not found: {name}"),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        _ => return Err(err("invalid commands field")),
+    }
+    Ok((out, broken))
+}
+
 #[derive(Debug)]
 pub(crate) struct BrokenSkill {
     pub name: String,
@@ -208,6 +265,41 @@ pub(crate) fn resolve_mcp_settings_targets(
     Ok(out)
 }
 
+pub(crate) fn resolve_command_destinations(
+    cfg: &Config,
+    scope: Scope,
+    project_root: &Path,
+) -> Result<Vec<PathBuf>> {
+    let agents = cfg.agents();
+    if agents.is_empty() {
+        return Ok(vec![]);
+    }
+    let mut seen = std::collections::HashSet::<PathBuf>::new();
+    let mut out = Vec::new();
+    match scope {
+        Scope::Project => {
+            for a in agents {
+                if let Some(path) = a.command_project_path(project_root) {
+                    if seen.insert(path.clone()) {
+                        out.push(path);
+                    }
+                }
+            }
+        }
+        Scope::Global => {
+            let home = dirs_home()?;
+            for a in agents {
+                if let Some(path) = a.command_global_path(&home) {
+                    if seen.insert(path.clone()) {
+                        out.push(path);
+                    }
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
 pub(crate) fn now_unix() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -231,8 +323,10 @@ pub(crate) fn temp_dir(prefix: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::AGENT_PRESETS;
     use crate::model::{
-        Agent, AgentField, Config, GitPin, McpEntry, McpsField, SkillTarget, SkillsField,
+        Agent, AgentField, CommandTarget, CommandsField, Config, GitPin, McpEntry, McpsField,
+        SkillTarget, SkillsField,
     };
     use std::path::Path;
 
@@ -281,6 +375,80 @@ mod tests {
     }
 
     #[test]
+    fn select_command_targets_supports_md_and_toml_overrides() {
+        let root = temp_dir("kasetto-command-targets");
+        let md_dir = root.join("md");
+        let toml_dir = root.join("toml");
+        fs::create_dir_all(&md_dir).expect("create md dir");
+        fs::create_dir_all(&toml_dir).expect("create toml dir");
+        fs::write(md_dir.join("review.md"), "# review\n").expect("write md");
+        fs::write(toml_dir.join("triage.toml"), "name='triage'\n").expect("write toml");
+
+        let mut available = HashMap::new();
+        available.insert("review".to_string(), PathBuf::from("/tmp/review.md"));
+        available.insert("triage".to_string(), PathBuf::from("/tmp/triage.toml"));
+
+        let cf = CommandsField::List(vec![
+            CommandTarget::Obj {
+                name: "review".to_string(),
+                path: Some(md_dir.to_string_lossy().to_string()),
+            },
+            CommandTarget::Obj {
+                name: "triage".to_string(),
+                path: Some(toml_dir.to_string_lossy().to_string()),
+            },
+        ]);
+
+        let (targets, broken) = select_command_targets(&cf, &available).expect("select commands");
+        assert!(broken.is_empty());
+        assert_eq!(targets.len(), 2);
+        assert!(targets
+            .iter()
+            .any(|(n, p)| n == "review" && p.ends_with("review.md")));
+        assert!(targets
+            .iter()
+            .any(|(n, p)| n == "triage" && p.ends_with("triage.toml")));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn resolve_command_destinations_for_supported_agents() {
+        let project_root = temp_dir("kasetto-command-destinations");
+        fs::create_dir_all(&project_root).expect("create project root");
+        let cfg: Config = serde_yaml::from_str(
+            "agent:\n  - claude-code\n  - opencode\n  - gemini-cli\nskills: []\n",
+        )
+        .expect("parse config");
+
+        let project_targets =
+            resolve_command_destinations(&cfg, Scope::Project, &project_root).expect("project");
+        assert!(project_targets
+            .iter()
+            .any(|p| p.ends_with(".claude/commands")));
+        assert!(project_targets
+            .iter()
+            .any(|p| p.ends_with(".agents/commands")));
+        assert!(project_targets
+            .iter()
+            .any(|p| p.ends_with(".gemini/commands")));
+
+        let global_targets =
+            resolve_command_destinations(&cfg, Scope::Global, &project_root).expect("global");
+        assert!(global_targets
+            .iter()
+            .any(|p| p.ends_with(".claude/commands")));
+        assert!(global_targets
+            .iter()
+            .any(|p| p.ends_with(".agents/commands")));
+        assert!(global_targets
+            .iter()
+            .any(|p| p.ends_with(".gemini/commands")));
+
+        let _ = fs::remove_dir_all(&project_root);
+    }
+
+    #[test]
     fn agent_paths_cover_supported_presets() {
         let home = Path::new("/tmp/kasetto-home");
 
@@ -294,6 +462,61 @@ mod tests {
             home.join(".codeium/windsurf/skills")
         );
         assert_eq!(Agent::Trae.global_path(home), home.join(".trae/skills"));
+        assert_eq!(
+            Agent::CopilotCli.global_path(home),
+            home.join(".copilot/skills")
+        );
+        assert_eq!(
+            Agent::CopilotCli.command_global_path(home),
+            Some(home.join(".agents/commands"))
+        );
+        assert_eq!(
+            Agent::ClaudeCode.command_global_path(home),
+            Some(home.join(".claude/commands"))
+        );
+    }
+
+    #[test]
+    fn agent_command_fallback_defaults_to_agents_commands() {
+        let home = Path::new("/tmp/kasetto-home");
+        let project_root = Path::new("/tmp/kasetto-project");
+        for a in AGENT_PRESETS {
+            let global = a.command_global_path(home);
+            let project = a.command_project_path(project_root);
+            match a {
+                Agent::Augment
+                | Agent::ClaudeCode
+                | Agent::GeminiCli
+                | Agent::Junie
+                | Agent::Roo
+                | Agent::Windsurf => {
+                    assert!(global.is_some(), "{a:?} should have a command path");
+                    assert_ne!(
+                        global.unwrap(),
+                        home.join(".agents/commands"),
+                        "{a:?} uses dedicated command dir"
+                    );
+                    assert!(project.is_some());
+                    assert_ne!(
+                        project.unwrap(),
+                        project_root.join(".agents/commands"),
+                        "{a:?} uses dedicated project command dir"
+                    );
+                }
+                _ => {
+                    assert_eq!(
+                        global,
+                        Some(home.join(".agents/commands")),
+                        "{a:?} should fall back to .agents/commands"
+                    );
+                    assert_eq!(
+                        project,
+                        Some(project_root.join(".agents/commands")),
+                        "{a:?} should fall back to project .agents/commands"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -22,6 +22,8 @@ pub(crate) enum Agent {
     ClaudeCode,
     #[serde(rename = "cline")]
     Cline,
+    #[serde(rename = "copilot-cli")]
+    CopilotCli,
     #[serde(rename = "codex")]
     Codex,
     #[serde(rename = "continue")]
@@ -63,6 +65,7 @@ pub(crate) const AGENT_PRESETS: &[Agent] = &[
     Agent::Augment,
     Agent::ClaudeCode,
     Agent::Cline,
+    Agent::CopilotCli,
     Agent::Codex,
     Agent::Continue,
     Agent::Cursor,
@@ -130,23 +133,46 @@ fn mcp_servers_target(base: &Path, rel: &str) -> McpSettingsTarget {
 }
 
 impl Agent {
+    pub(crate) fn command_global_path(self, home: &Path) -> Option<PathBuf> {
+        match self {
+            Agent::Augment => Some(home.join(".augment/commands")),
+            Agent::ClaudeCode => Some(home.join(".claude/commands")),
+            Agent::GeminiCli => Some(home.join(".gemini/commands")),
+            Agent::Junie => Some(home.join(".junie/commands")),
+            Agent::Roo => Some(home.join(".roo/commands")),
+            Agent::Windsurf => Some(home.join(".windsurf/workflows")),
+            _ => Some(home.join(".agents/commands")),
+        }
+    }
+
+    pub(crate) fn command_project_path(self, project_root: &Path) -> Option<PathBuf> {
+        match self {
+            Agent::Augment => Some(project_root.join(".augment/commands")),
+            Agent::ClaudeCode => Some(project_root.join(".claude/commands")),
+            Agent::GeminiCli => Some(project_root.join(".gemini/commands")),
+            Agent::Junie => Some(project_root.join(".junie/commands")),
+            Agent::Roo => Some(project_root.join(".roo/commands")),
+            Agent::Windsurf => Some(project_root.join(".windsurf/workflows")),
+            _ => Some(project_root.join(".agents/commands")),
+        }
+    }
+
     pub(crate) fn global_path(self, home: &Path) -> PathBuf {
         match self {
             Agent::Amp | Agent::Replit => home.join(".config/agents/skills"),
             Agent::Antigravity => home.join(".gemini/antigravity/skills"),
             Agent::Augment => home.join(".augment/skills"),
             Agent::ClaudeCode => home.join(".claude/skills"),
-            Agent::Cline | Agent::Warp => home.join(".agents/skills"),
+            Agent::Cline | Agent::Warp | Agent::OpenCode => home.join(".agents/skills"),
             Agent::Codex => home.join(".codex/skills"),
             Agent::Continue => home.join(".continue/skills"),
             Agent::Cursor => home.join(".cursor/skills"),
             Agent::GeminiCli => home.join(".gemini/skills"),
-            Agent::GithubCopilot => home.join(".copilot/skills"),
+            Agent::GithubCopilot | Agent::CopilotCli => home.join(".copilot/skills"),
             Agent::Goose => home.join(".config/goose/skills"),
             Agent::Junie => home.join(".junie/skills"),
             Agent::KiroCli => home.join(".kiro/skills"),
             Agent::OpenClaw => home.join(".openclaw/skills"),
-            Agent::OpenCode => home.join(".config/opencode/skills"),
             Agent::OpenHands => home.join(".openhands/skills"),
             Agent::Roo => home.join(".roo/skills"),
             Agent::Trae => home.join(".trae/skills"),
@@ -178,6 +204,7 @@ impl Agent {
             Agent::Antigravity => mcp_servers_target(home, ".gemini/antigravity/mcp.json"),
             Agent::Augment => mcp_servers_target(home, ".augment/mcp.json"),
             Agent::Warp => mcp_servers_target(home, ".warp/mcp.json"),
+            Agent::CopilotCli => mcp_servers_target(home, ".copilot/mcp-config.json"),
             Agent::Codex => McpSettingsTarget {
                 path: home.join(".codex/config.toml"),
                 format: McpSettingsFormat::CodexToml,
@@ -202,17 +229,16 @@ impl Agent {
             Agent::Antigravity => project_root.join(".gemini/antigravity/skills"),
             Agent::Augment => project_root.join(".augment/skills"),
             Agent::ClaudeCode => project_root.join(".claude/skills"),
-            Agent::Cline | Agent::Warp => project_root.join(".agents/skills"),
+            Agent::Cline | Agent::Warp | Agent::OpenCode => project_root.join(".agents/skills"),
             Agent::Codex => project_root.join(".codex/skills"),
             Agent::Continue => project_root.join(".continue/skills"),
             Agent::Cursor => project_root.join(".cursor/skills"),
             Agent::GeminiCli => project_root.join(".gemini/skills"),
-            Agent::GithubCopilot => project_root.join(".copilot/skills"),
+            Agent::GithubCopilot | Agent::CopilotCli => project_root.join(".copilot/skills"),
             Agent::Goose => project_root.join(".goose/skills"),
             Agent::Junie => project_root.join(".junie/skills"),
             Agent::KiroCli => project_root.join(".kiro/skills"),
             Agent::OpenClaw => project_root.join(".openclaw/skills"),
-            Agent::OpenCode => project_root.join(".opencode/skills"),
             Agent::OpenHands => project_root.join(".openhands/skills"),
             Agent::Roo => project_root.join(".roo/skills"),
             Agent::Trae => project_root.join(".trae/skills"),
@@ -251,6 +277,7 @@ impl Agent {
                 path: project_root.join(".opencode/opencode.json"),
                 format: McpSettingsFormat::OpenCode,
             },
+            Agent::CopilotCli => mcp_servers_target(project_root, ".copilot/mcp-config.json"),
             Agent::Antigravity
             | Agent::Augment
             | Agent::Goose

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -22,6 +22,8 @@ pub(crate) struct Config {
     pub skills: Vec<SourceSpec>,
     #[serde(default)]
     pub mcps: Vec<McpSourceSpec>,
+    #[serde(default)]
+    pub commands: Vec<CommandSourceSpec>,
 }
 
 impl Config {
@@ -117,6 +119,27 @@ pub(crate) struct McpSourceSpec {
     pub mcps: McpsField,
 }
 
+#[derive(Debug, Deserialize)]
+pub(crate) struct CommandSourceSpec {
+    pub source: String,
+    pub branch: Option<String>,
+    #[serde(rename = "ref")]
+    pub git_ref: Option<String>,
+    pub commands: CommandsField,
+}
+
+impl CommandSourceSpec {
+    pub(crate) fn as_source_spec(&self) -> SourceSpec {
+        SourceSpec {
+            source: self.source.clone(),
+            branch: self.branch.clone(),
+            git_ref: self.git_ref.clone(),
+            sub_dir: None,
+            skills: SkillsField::Wildcard("*".to_string()),
+        }
+    }
+}
+
 impl McpSourceSpec {
     pub(crate) fn as_source_spec(&self) -> SourceSpec {
         SourceSpec {
@@ -161,6 +184,20 @@ pub(crate) enum SkillsField {
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub(crate) enum SkillTarget {
+    Name(String),
+    Obj { name: String, path: Option<String> },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum CommandsField {
+    Wildcard(String),
+    List(Vec<CommandTarget>),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum CommandTarget {
     Name(String),
     Obj { name: String, path: Option<String> },
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -4,9 +4,12 @@ mod types;
 
 use std::path::PathBuf;
 
+#[cfg(test)]
+pub(crate) use agent::AGENT_PRESETS;
 pub(crate) use agent::{all_mcp_project_targets, all_mcp_settings_targets, Agent, AgentField};
 pub(crate) use config::{
-    resolve_scope, Config, GitPin, McpEntry, McpsField, Scope, SkillTarget, SkillsField, SourceSpec,
+    resolve_scope, CommandTarget, CommandsField, Config, GitPin, McpEntry, McpsField, Scope,
+    SkillTarget, SkillsField, SourceSpec,
 };
 pub(crate) use types::{Action, InstalledSkill, Report, SkillEntry, State, Summary, SyncFailure};
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -246,6 +246,43 @@ pub(crate) fn resolve_mcp_entry(root: &Path, entry: &crate::model::McpEntry) -> 
     }
 }
 
+pub(crate) fn discover_commands(root: &Path) -> Result<HashMap<String, PathBuf>> {
+    let mut out = HashMap::new();
+    discover_commands_in_subdir(&root.join("commands"), &mut out)?;
+    discover_commands_in_subdir(&root.join("workflows"), &mut out)?;
+    discover_commands_in_subdir(&root.join(".claude/commands"), &mut out)?;
+    discover_commands_in_subdir(&root.join(".augment/commands"), &mut out)?;
+    discover_commands_in_subdir(&root.join(".gemini/commands"), &mut out)?;
+    discover_commands_in_subdir(&root.join(".junie/commands"), &mut out)?;
+    discover_commands_in_subdir(&root.join(".roo/commands"), &mut out)?;
+    discover_commands_in_subdir(&root.join(".windsurf/workflows"), &mut out)?;
+    discover_commands_in_subdir(&root.join(".opencode/commands"), &mut out)?;
+    Ok(out)
+}
+
+fn discover_commands_in_subdir(base: &Path, out: &mut HashMap<String, PathBuf>) -> Result<()> {
+    if !base.exists() {
+        return Ok(());
+    }
+    for e in fs::read_dir(base)? {
+        let e = e?;
+        if !e.file_type()?.is_file() {
+            continue;
+        }
+        let p = e.path();
+        let is_supported = p
+            .extension()
+            .map(|ext| ext == "md" || ext == "toml")
+            .unwrap_or(false);
+        if is_supported {
+            if let Some(stem) = p.file_stem() {
+                out.insert(stem.to_string_lossy().to_string(), p);
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -490,6 +527,41 @@ mod tests {
         };
         let path = resolve_mcp_entry(&root, &entry).unwrap();
         assert!(path.ends_with("mcps/server.json"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn discover_commands_finds_markdown_and_toml_variants() {
+        let root = temp_dir("kasetto-cmd-discover");
+        fs::create_dir_all(root.join("commands")).unwrap();
+        fs::create_dir_all(root.join(".gemini/commands")).unwrap();
+        fs::create_dir_all(root.join(".windsurf/workflows")).unwrap();
+
+        fs::write(root.join("commands/review.md"), "# Review\n").unwrap();
+        fs::write(root.join(".gemini/commands/triage.toml"), "name='triage'\n").unwrap();
+        fs::write(root.join(".windsurf/workflows/polish.md"), "# Polish\n").unwrap();
+
+        let commands = discover_commands(&root).unwrap();
+        assert!(commands.contains_key("review"));
+        assert!(commands.contains_key("triage"));
+        assert!(commands.contains_key("polish"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn discover_commands_prefers_later_discovery_paths() {
+        let root = temp_dir("kasetto-cmd-precedence");
+        fs::create_dir_all(root.join("commands")).unwrap();
+        fs::create_dir_all(root.join(".opencode/commands")).unwrap();
+
+        fs::write(root.join("commands/dup.md"), "# first\n").unwrap();
+        fs::write(root.join(".opencode/commands/dup.md"), "# second\n").unwrap();
+
+        let commands = discover_commands(&root).unwrap();
+        let picked = commands.get("dup").expect("dup discovered");
+        assert!(picked.ends_with(".opencode/commands/dup.md"));
 
         let _ = fs::remove_dir_all(&root);
     }


### PR DESCRIPTION
## Summary

Adds support for syncing custom command and workflow files (`.md` and `.toml`) into supported AI agent harness directories, alongside the existing skills and MCP server management.

## What changed

**New `commands:` config block**
- Mirrors the existing `skills:` and `mcps:` source patterns
- Supports `"*"` wildcard or explicit list of names / `{ name, path }` objects
- Discovers `.md` and `.toml` files from conventional directories:
  - `commands/`, `workflows/`
  - `.claude/commands/`, `.augment/commands/`, `.gemini/commands/`
  - `.junie/commands/`, `.roo/commands/`, `.windsurf/workflows/`, `.opencode/commands/`

**Supported agents for commands**
- `claude-code`, `augment`, `gemini-cli`, `junie`, `roo`, `windsurf`, `opencode`

**Sync behavior**
- Commands are hashed and tracked in the lock file (like skills and MCPs)
- Only changed commands are copied on re-sync
- Removed commands are cleaned up automatically
- `kst clean` removes tracked command files

**Documentation updates**
- README.md: added commands to feature list, config example, and reference table
- docs/configuration.md: full `commands:` reference with discovery rules
- docs/agents.md: command support matrix per agent
- docs/how-sync-works.md: commands in the sync flow, lock file, and cleanup sections
- docs/commands.md: updated `sync`, `clean`, and `self uninstall` descriptions
- docs/index.md: new "Commands" quick-start section
- docs/cookbook.md: custom commands recipe
- docs/security.md, faq.md, authentication.md: updated to mention commands

## Example config

```yaml
agent: claude-code

skills:
  - source: https://github.com/org/skill-pack
    skills: "*"

commands:
  - source: https://github.com/org/opencode-commands
    commands:
      - review-changes
      - name: deep-dive
        path: workflows
```

## Testing

- 126 tests passing (including new tests for command discovery, sync, and clean)
