### PR TITLE
feat: add post/pre sync command hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- **hooks**: `pre_sync` and `post_sync` hooks in the YAML config. Run shell commands before or after sync with `--no-hooks` to skip. Defined in local or global config; local takes priority when both exist. `post_sync` hooks receive the sync report via `KASETTO_*` environment variables.
+
 ## [2.6.1] - 2026-05-07
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ kst sync [--config <path-or-url>] [--dry-run] [--quiet] [--json] [--plain] [--ve
 | `--json`    | Print the sync report as JSON                                                                                                                      |
 | `--plain`   | Disable colors and spinner animations                                                                                                              |
 | `--verbose` | Show per-skill action details                                                                                                                      |
+| `--no-hooks` | Skip pre_sync and post_sync hook execution                                                                                                       |
 | `--project` | Install into the current project directory                                                                                                         |
 | `--global`  | Install globally (default)                                                                                                                         |
 
@@ -261,6 +262,14 @@ mcps:
     mcps:
       - github        # → mcps/github.json
       - linear        # → mcps/linear.json
+
+# Hooks (optional) — define hooks in local or global config.
+# If both exist, local takes priority.
+hooks:
+  pre_sync:
+    - echo "Starting sync..."
+  post_sync:
+    - echo "Synced $KASETTO_INSTALLED skills, $KASETTO_UPDATED updated"
 ```
 
 | Key                | Required | Description                                                                  |
@@ -279,6 +288,9 @@ mcps:
 | `mcps[].branch`    | no       | Branch for remote sources                                                    |
 | `mcps[].ref`       | no       | Git tag, commit SHA, or ref                                                  |
 | `mcps[].mcps`      | **yes**  | `"*"` to discover all, or a list of names / `{ name, path }` objects         |
+| `hooks`            | no       | Optional `pre_sync` and `post_sync` hook commands                            |
+| `hooks.pre_sync`   | no       | Shell commands to run before sync (failure aborts)                           |
+| `hooks.post_sync`  | no       | Shell commands to run after sync (receives report via `KASETTO_*` env vars)  |
 
 ## Supported Agents
 
@@ -347,7 +359,6 @@ The same tokens apply when you fetch a remote config via `--config https://...`.
 ## Roadmap
 
 - Agents management
-- Hooks management
 - Audit command — scan config and MCP servers for security issues
 - Smart URL rewriting — auto-rewrite GitHub `/blob/` URLs to raw content
 - Your idea? [Open an issue](https://github.com/pivoshenko/kasetto/issues)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,6 +33,7 @@ kst sync [OPTIONS]
 | `--json`                 | Print the sync report as JSON                                |
 | `--plain`                | Disable colors and spinner animations                        |
 | `--verbose`              | Show per-skill action details                                |
+| `--no-hooks`             | Skip `pre_sync` and `post_sync` hook execution               |
 | `--project`              | Install into the current project directory                   |
 | `--global`               | Install globally (default)                                   |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,13 @@ mcps:
     mcps:
       - name: my-server
         path: tools   # → tools/my-server.json
+
+# Hooks (optional)
+hooks:
+  pre_sync:
+    - ./scripts/validate-skills.sh
+  post_sync:
+    - echo "Synced $KASETTO_INSTALLED skills"
 ```
 
 ## Reference
@@ -80,6 +87,7 @@ mcps:
 | `scope`       | no       | `"global"` (default) or `"project"` - where to install              |
 | `skills`      | **yes**  | List of skill sources                                               |
 | `mcps`        | no       | List of MCP server sources                                          |
+| `hooks`       | no       | Optional `pre_sync` and `post_sync` hook commands                   |
 
 ### Skill Source Fields
 
@@ -140,6 +148,51 @@ Paths are resolved relative to the source root (or `sub-dir` if set); absolute p
 MCP config files must contain a `mcpServers` object with server definitions. Servers are merged
 into each agent's native settings file (e.g., `.claude.json` for Claude Code, `.cursor/mcp.json`
 for Cursor). See [how sync works](./how-sync-works.md) for merge behavior details.
+
+## Hooks
+
+Define shell commands that run before or after `kst sync`. Hooks can be placed in your **local**
+`kasetto.yaml` or in the **global** config at `~/.config/kasetto/kasetto.yaml`.
+
+If both the local and global config define hooks, **local takes priority** and the global hooks
+are ignored entirely.
+
+### Example
+
+```yaml
+hooks:
+  pre_sync:
+    - echo "Starting sync..."
+    - ./scripts/validate-skills.sh
+  post_sync:
+    - echo "Synced $KASETTO_INSTALLED skills, updated $KASETTO_UPDATED"
+    - curl -X POST https://hooks.slack.com/... -d '{"text":"Kasetto sync complete"}'
+```
+
+### Reference
+
+| Key               | Description                                                                   |
+| ----------------- | ----------------------------------------------------------------------------- |
+| `hooks`           | Object containing `pre_sync` and/or `post_sync` arrays                        |
+| `hooks.pre_sync`  | Shell commands run before sync via `sh -c`. Any failure aborts the sync.      |
+| `hooks.post_sync` | Shell commands run after sync completes. Receives report via `KASETTO_*` env vars. |
+
+Hooks run in the order listed. Use `--no-hooks` to skip all hooks for a single run.
+
+`post_sync` hooks receive the following environment variables:
+
+| Variable              | Example value        |
+| --------------------- | -------------------- |
+| `KASETTO_RUN_ID`      | `1746700000`         |
+| `KASETTO_CONFIG`      | `kasetto.yaml`       |
+| `KASETTO_DESTINATION` | `/home/user/.codex/skills` |
+| `KASETTO_DRY_RUN`     | `0` or `1`           |
+| `KASETTO_INSTALLED`   | `2`                  |
+| `KASETTO_UPDATED`     | `1`                  |
+| `KASETTO_REMOVED`     | `0`                  |
+| `KASETTO_UNCHANGED`   | `5`                  |
+| `KASETTO_BROKEN`      | `0`                  |
+| `KASETTO_FAILED`      | `0`                  |
 
 ## Remote Configs
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,7 +3,6 @@
 Planned features for future releases:
 
 - **Agents management** — list detected agents, show their install paths, and check whether agent binaries are present on the system
-- **Hooks management** — run user-defined commands before or after sync (e.g., reload an agent, run a linter, send a notification)
 - **Audit command** — scan config and installed MCP servers for security issues (unpinned sources, suspicious commands, overly broad permissions)
 - **Library crate** — extract the core sync engine, model types, and MCP merging into a standalone library so other tools can embed kasetto programmatically ([#22](https://github.com/pivoshenko/kasetto/issues/22))
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,6 +21,7 @@ pub fn run() -> Result<()> {
                     as_json: sync.json,
                     plain: sync.plain,
                     verbose: sync.verbose,
+                    no_hooks: sync.no_hooks,
                     scope_override: sync.scope.scope_override(),
                     show_banner: true,
                 })

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,6 +82,9 @@ pub(crate) struct SyncArgs {
     #[arg(long)]
     #[arg(help = "print per-skill action list")]
     pub verbose: bool,
+    #[arg(long)]
+    #[arg(help = "skip pre_sync and post_sync hooks")]
+    pub no_hooks: bool,
     #[command(flatten)]
     pub scope: ScopeArgs,
 }

--- a/src/commands/sync/hooks.rs
+++ b/src/commands/sync/hooks.rs
@@ -1,0 +1,81 @@
+use std::process::Command;
+
+use crate::error::{err, Result};
+use crate::model::Report;
+use crate::ui::with_spinner;
+
+use super::SyncContext;
+
+/// Run a list of shell commands as hooks.
+///
+/// - `hooks`: command strings to execute via `sh -c`
+/// - `label`: display label like "pre-sync" or "post-sync"
+/// - `env_vars`: extra environment variables to inject
+///
+/// Hooks run in order. The first failure aborts the remaining hooks and
+/// returns an error.
+pub(super) fn run_hooks(
+    ctx: &SyncContext,
+    hooks: &[String],
+    label: &str,
+    env_vars: &[(&str, &str)],
+) -> Result<()> {
+    if hooks.is_empty() {
+        return Ok(());
+    }
+
+    for (idx, cmd_str) in hooks.iter().enumerate() {
+        let spinner_label = format!("Running {label} hook {}/{}", idx + 1, hooks.len());
+
+        with_spinner(ctx.animate, ctx.plain, &spinner_label, || {
+            let status = Command::new("sh")
+                .arg("-c")
+                .arg(cmd_str)
+                .envs(env_vars.iter().map(|(k, v)| (*k, *v)))
+                .status()
+                .map_err(|e| {
+                    err(format!(
+                        "{label} hook {}/{hooks_len} failed to start: {e}",
+                        idx + 1,
+                        hooks_len = hooks.len()
+                    ))
+                })?;
+
+            if !status.success() {
+                return Err(err(format!(
+                    "{label} hook {}/{hooks_len} exited with status: {status}",
+                    idx + 1,
+                    hooks_len = hooks.len(),
+                    status = status
+                )));
+            }
+
+            Ok(())
+        })?;
+    }
+
+    Ok(())
+}
+
+/// Build environment variables for post_sync hooks based on the sync report.
+pub(super) fn post_sync_env(report: &Report) -> Vec<(&'static str, String)> {
+    vec![
+        ("KASETTO_RUN_ID", report.run_id.clone()),
+        ("KASETTO_CONFIG", report.config.clone()),
+        ("KASETTO_DESTINATION", report.destination.clone()),
+        (
+            "KASETTO_DRY_RUN",
+            if report.dry_run {
+                "1".into()
+            } else {
+                "0".into()
+            },
+        ),
+        ("KASETTO_INSTALLED", report.summary.installed.to_string()),
+        ("KASETTO_UPDATED", report.summary.updated.to_string()),
+        ("KASETTO_REMOVED", report.summary.removed.to_string()),
+        ("KASETTO_UNCHANGED", report.summary.unchanged.to_string()),
+        ("KASETTO_BROKEN", report.summary.broken.to_string()),
+        ("KASETTO_FAILED", report.summary.failed.to_string()),
+    ]
+}

--- a/src/commands/sync/mod.rs
+++ b/src/commands/sync/mod.rs
@@ -1,3 +1,4 @@
+mod hooks;
 mod mcps;
 mod skills;
 
@@ -9,7 +10,7 @@ use crate::colors::{ACCENT, ATTENTION, ERROR, INFO, RESET, SECONDARY, SUCCESS, W
 use crate::error::Result;
 use crate::fsops::{load_config_any, now_iso, now_unix, resolve_destinations};
 use crate::lock::{load_lock, save_lock};
-use crate::model::{resolve_scope, Config, Report, Scope, Summary};
+use crate::model::{resolve_scope, Config, Hooks, Report, Scope, Summary};
 use crate::ui::{animations_enabled, print_json, status_chip};
 
 pub(super) struct SyncContext<'a> {
@@ -32,8 +33,33 @@ pub(crate) struct SyncOptions<'a> {
     pub as_json: bool,
     pub plain: bool,
     pub verbose: bool,
+    pub no_hooks: bool,
     pub scope_override: Option<Scope>,
     pub show_banner: bool,
+}
+
+/// Load hooks from the local `kasetto.yaml` if it exists, falling back to the
+/// global config. If both define hooks, local wins.
+fn resolve_hooks() -> Option<Hooks> {
+    let local_path = crate::DEFAULT_CONFIG_FILENAME;
+    if let Ok(text) = std::fs::read_to_string(local_path) {
+        if let Ok(cfg) = serde_yaml::from_str::<Config>(&text) {
+            if cfg.hooks.is_some() {
+                return cfg.hooks;
+            }
+        }
+    }
+
+    if let Ok(global_dir) = crate::fsops::dirs_kasetto_config() {
+        let global_path = global_dir.join(crate::DEFAULT_GLOBAL_CONFIG_FILENAME);
+        if let Ok(text) = std::fs::read_to_string(&global_path) {
+            if let Ok(cfg) = serde_yaml::from_str::<Config>(&text) {
+                return cfg.hooks;
+            }
+        }
+    }
+
+    None
 }
 
 pub(crate) fn run(opts: &SyncOptions) -> Result<()> {
@@ -68,6 +94,12 @@ pub(crate) fn run(opts: &SyncOptions) -> Result<()> {
         quiet: opts.quiet,
     };
 
+    let hooks = if opts.no_hooks { None } else { resolve_hooks() };
+
+    if let Some(ref h) = hooks {
+        hooks::run_hooks(&ctx, &h.pre_sync, "pre-sync", &[])?;
+    }
+
     let mut lock = load_lock(scope, &cfg_dir)?;
     let mut state = lock.state();
     let mut summary = Summary::default();
@@ -93,6 +125,12 @@ pub(crate) fn run(opts: &SyncOptions) -> Result<()> {
     if !opts.dry_run {
         lock.save_report_json(&serde_json::to_string(&report)?);
         save_lock(&lock, scope, &cfg_dir)?;
+    }
+
+    if let Some(ref h) = hooks {
+        let env = hooks::post_sync_env(&report);
+        let env_ref: Vec<(&str, &str)> = env.iter().map(|(k, v)| (*k, v.as_str())).collect();
+        hooks::run_hooks(&ctx, &h.post_sync, "post-sync", &env_ref)?;
     }
 
     if opts.as_json {
@@ -201,4 +239,141 @@ pub(super) fn file_name_str(path: &std::path::Path) -> String {
         .unwrap_or_default()
         .to_string_lossy()
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+
+    /// Serialise hook-resolution tests because they mutate the process-wide
+    /// current-working directory and `XDG_CONFIG_HOME`.
+    static HOOKS_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn temp_dir(prefix: &str) -> std::path::PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{}-{nonce}", std::process::id()))
+    }
+
+    #[test]
+    fn resolve_hooks_prefers_local() {
+        let _guard = HOOKS_TEST_LOCK.lock().unwrap();
+
+        let dir = temp_dir("kasetto-hooks-local");
+        fs::create_dir_all(&dir).unwrap();
+        let local_cfg = dir.join("kasetto.yaml");
+        fs::write(
+            &local_cfg,
+            r#"
+agent: cursor
+skills: []
+hooks:
+  pre_sync:
+    - echo local
+"#,
+        )
+        .unwrap();
+
+        let global_dir = dir.join("global");
+        fs::create_dir_all(&global_dir).unwrap();
+        let global_cfg = global_dir.join("kasetto").join("kasetto.yaml");
+        fs::create_dir_all(global_cfg.parent().unwrap()).unwrap();
+        fs::write(
+            &global_cfg,
+            r#"
+agent: cursor
+skills: []
+hooks:
+  pre_sync:
+    - echo global
+"#,
+        )
+        .unwrap();
+
+        let _orig_local = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&dir).unwrap();
+        let _orig_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::set_var("XDG_CONFIG_HOME", &global_dir);
+
+        let hooks = resolve_hooks();
+        assert!(hooks.is_some());
+        assert_eq!(hooks.unwrap().pre_sync, vec!["echo local"]);
+
+        let _ = fs::remove_dir_all(&dir);
+        if let Some(v) = _orig_xdg {
+            std::env::set_var("XDG_CONFIG_HOME", v);
+        } else {
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+        std::env::set_current_dir(_orig_local).unwrap();
+    }
+
+    #[test]
+    fn resolve_hooks_falls_back_to_global() {
+        let _guard = HOOKS_TEST_LOCK.lock().unwrap();
+
+        let dir = temp_dir("kasetto-hooks-global");
+        fs::create_dir_all(&dir).unwrap();
+
+        let global_dir = dir.join("global");
+        fs::create_dir_all(&global_dir).unwrap();
+        let global_cfg = global_dir.join("kasetto").join("kasetto.yaml");
+        fs::create_dir_all(global_cfg.parent().unwrap()).unwrap();
+        fs::write(
+            &global_cfg,
+            r#"
+agent: cursor
+skills: []
+hooks:
+  pre_sync:
+    - echo global
+"#,
+        )
+        .unwrap();
+
+        let _orig_local = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&dir).unwrap();
+        let _orig_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::set_var("XDG_CONFIG_HOME", &global_dir);
+
+        let hooks = resolve_hooks();
+        assert!(hooks.is_some());
+        assert_eq!(hooks.unwrap().pre_sync, vec!["echo global"]);
+
+        let _ = fs::remove_dir_all(&dir);
+        if let Some(v) = _orig_xdg {
+            std::env::set_var("XDG_CONFIG_HOME", v);
+        } else {
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+        std::env::set_current_dir(_orig_local).unwrap();
+    }
+
+    #[test]
+    fn resolve_hooks_returns_none_when_neither_exists() {
+        let _guard = HOOKS_TEST_LOCK.lock().unwrap();
+
+        let dir = temp_dir("kasetto-hooks-none");
+        fs::create_dir_all(&dir).unwrap();
+
+        let _orig_local = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&dir).unwrap();
+        let _orig_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::set_var("XDG_CONFIG_HOME", &dir);
+
+        let hooks = resolve_hooks();
+        assert!(hooks.is_none());
+
+        let _ = fs::remove_dir_all(&dir);
+        if let Some(v) = _orig_xdg {
+            std::env::set_var("XDG_CONFIG_HOME", v);
+        } else {
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+        std::env::set_current_dir(_orig_local).unwrap();
+    }
 }

--- a/src/commands/sync/skills.rs
+++ b/src/commands/sync/skills.rs
@@ -24,8 +24,11 @@ pub(super) fn sync_skills(
         let stage = std::env::temp_dir().join(format!("kasetto-{}-{}", now_unix(), i));
         match materialize_source(src, ctx.cfg_dir, &stage) {
             Ok(materialized) => {
-                let (targets, broken_skills) =
-                    select_targets(&src.skills, &materialized.available, &materialized.source_root)?;
+                let (targets, broken_skills) = select_targets(
+                    &src.skills,
+                    &materialized.available,
+                    &materialized.source_root,
+                )?;
 
                 record_broken_skills(ctx, &src.source, broken_skills, summary, actions);
 

--- a/src/fsops/mod.rs
+++ b/src/fsops/mod.rs
@@ -260,8 +260,7 @@ mod tests {
             SkillTarget::Name("missing".to_string()),
         ]);
 
-        let (targets, broken) =
-            select_targets(&sf, &available, Path::new("/tmp")).expect("select");
+        let (targets, broken) = select_targets(&sf, &available, Path::new("/tmp")).expect("select");
         assert_eq!(targets.len(), 1);
         assert_eq!(targets[0].0, "present");
         assert_eq!(broken.len(), 1);
@@ -287,8 +286,7 @@ mod tests {
             path: Some(nested.to_string_lossy().to_string()),
         }]);
 
-        let (targets, broken) =
-            select_targets(&sf, &available, Path::new("/tmp")).expect("select");
+        let (targets, broken) = select_targets(&sf, &available, Path::new("/tmp")).expect("select");
         assert!(broken.is_empty());
         assert_eq!(targets.len(), 1);
         assert_eq!(targets[0].0, "custom-skill");
@@ -598,5 +596,36 @@ mcps:
         assert!(
             matches!(&entries[0], McpEntry::Obj { name, path: Some(p) } if name == "my-server" && p == "tools")
         );
+    }
+
+    #[test]
+    fn config_parses_hooks() {
+        let yaml = r#"
+agent: cursor
+skills: []
+hooks:
+  pre_sync:
+    - echo "before"
+    - ./scripts/validate.sh
+  post_sync:
+    - echo "after"
+"#;
+        let cfg: Config = serde_yaml::from_str(yaml).expect("parse");
+        let hooks = cfg.hooks.expect("hooks present");
+        assert_eq!(
+            hooks.pre_sync,
+            vec!["echo \"before\"", "./scripts/validate.sh"]
+        );
+        assert_eq!(hooks.post_sync, vec!["echo \"after\""]);
+    }
+
+    #[test]
+    fn config_hooks_optional() {
+        let yaml = r#"
+agent: cursor
+skills: []
+"#;
+        let cfg: Config = serde_yaml::from_str(yaml).expect("parse");
+        assert!(cfg.hooks.is_none());
     }
 }

--- a/src/home/mod.rs
+++ b/src/home/mod.rs
@@ -35,6 +35,7 @@ pub(crate) fn run(program_name: &str, default_config: &str) -> Result<()> {
                 as_json: sync.json,
                 plain: sync.plain,
                 verbose: sync.verbose,
+                no_hooks: sync.no_hooks,
                 scope_override: sync.scope.scope_override(),
                 show_banner: true,
             })

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -12,6 +12,14 @@ pub(crate) enum Scope {
 }
 
 #[derive(Debug, Deserialize)]
+pub(crate) struct Hooks {
+    #[serde(default)]
+    pub pre_sync: Vec<String>,
+    #[serde(default)]
+    pub post_sync: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
 pub(crate) struct Config {
     pub destination: Option<String>,
     #[serde(default)]
@@ -22,6 +30,7 @@ pub(crate) struct Config {
     pub skills: Vec<SourceSpec>,
     #[serde(default)]
     pub mcps: Vec<McpSourceSpec>,
+    pub hooks: Option<Hooks>,
 }
 
 impl Config {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -6,7 +6,8 @@ use std::path::PathBuf;
 
 pub(crate) use agent::{all_mcp_project_targets, all_mcp_settings_targets, Agent, AgentField};
 pub(crate) use config::{
-    resolve_scope, Config, GitPin, McpEntry, McpsField, Scope, SkillTarget, SkillsField, SourceSpec,
+    resolve_scope, Config, GitPin, Hooks, McpEntry, McpsField, Scope, SkillTarget, SkillsField,
+    SourceSpec,
 };
 pub(crate) use types::{Action, InstalledSkill, Report, SkillEntry, State, Summary, SyncFailure};
 


### PR DESCRIPTION
## Summary

Adds hooks management to kasetto — user-defined shell commands that run before or after sync. Defined in the YAML config, resolved from local or global scope.

Closes #19.

## What's included

- **`hooks` config section** with `pre_sync` and `post_sync` arrays of shell commands
- **Scope resolution**: local `kasetto.yaml` wins over global `~/.config/kasetto/kasetto.yaml`. If both exist, only local hooks run. Falls back to global when local has none.
- **`--no-hooks` flag** on `kst sync` to skip all hooks
- **Execution model**: commands run via `sh -c` in order. A failing `pre_sync` hook aborts the sync with an error. A failing `post_sync` hook does the same.
- **Report env vars**: `post_sync` hooks receive `KASETTO_RUN_ID`, `KASETTO_CONFIG`, `KASETTO_DESTINATION`, `KASETTO_DRY_RUN`, `KASETTO_INSTALLED`, `KASETTO_UPDATED`, `KASETTO_REMOVED`, `KASETTO_UNCHANGED`, `KASETTO_BROKEN`, and `KASETTO_FAILED`.

## Example

```yaml
hooks:
  pre_sync:
    - echo "Starting sync..."
    - ./scripts/validate-skills.sh
  post_sync:
    - echo "Installed $KASETTO_INSTALLED skills, updated $KASETTO_UPDATED"
```

## Review notes

- Docs updated: README, configuration reference, commands reference, roadmap, changelog
- New module: `src/commands/sync/hooks.rs`
- Hook resolution tests are serialized behind a `Mutex` since they mutate the process-wide cwd