### PR TITLE
fix(sync): make revision skip safe for remote sources

### DIFF
--- a/src/commands/sync/skills.rs
+++ b/src/commands/sync/skills.rs
@@ -4,9 +4,9 @@ use std::path::Path;
 
 use crate::error::Result;
 use crate::fsops::{copy_dir, hash_dir, now_iso, now_unix, select_targets, BrokenSkill};
-use crate::model::{Action, SkillEntry, State, Summary};
+use crate::model::{Action, SkillEntry, SkillTarget, SkillsField, SourceSpec, State, Summary};
 use crate::profile::read_skill_profile_from_dir;
-use crate::source::materialize_source;
+use crate::source::{materialize_source, resolve_source_revision, UNKNOWN_REMOTE_REVISION};
 use crate::ui::{eprint_fail, with_spinner};
 
 use super::{sync_label, SyncContext};
@@ -21,11 +21,38 @@ pub(super) fn sync_skills(
     let destination = &ctx.destinations[0];
 
     for (i, src) in ctx.cfg.skills.iter().enumerate() {
+        // For remote sources, try to skip materialization when the revision hasn't changed
+        if src.source.contains("://") {
+            let stored_revision = state
+                .skills
+                .values()
+                .find(|e| e.source == src.source)
+                .map(|e| &e.source_revision);
+            if let Some(prev) = stored_revision {
+                if let Some(current) = resolve_source_revision(src) {
+                    if current == *prev
+                        && record_unchanged_source_selection(
+                            src,
+                            &current,
+                            state,
+                            &mut desired_keys,
+                            summary,
+                            actions,
+                        )
+                    {
+                        continue;
+                    }
+                }
+            }
+        }
         let stage = std::env::temp_dir().join(format!("kasetto-{}-{}", now_unix(), i));
         match materialize_source(src, ctx.cfg_dir, &stage) {
             Ok(materialized) => {
-                let (targets, broken_skills) =
-                    select_targets(&src.skills, &materialized.available, &materialized.source_root)?;
+                let (targets, broken_skills) = select_targets(
+                    &src.skills,
+                    &materialized.available,
+                    &materialized.source_root,
+                )?;
 
                 record_broken_skills(ctx, &src.source, broken_skills, summary, actions);
 
@@ -63,6 +90,79 @@ pub(super) fn sync_skills(
 
     remove_stale_skills(ctx, state, &desired_keys, summary, actions);
     Ok(())
+}
+
+fn record_unchanged_source_selection(
+    src: &SourceSpec,
+    current_revision: &str,
+    state: &State,
+    desired_keys: &mut HashSet<String>,
+    summary: &mut Summary,
+    actions: &mut Vec<Action>,
+) -> bool {
+    let selected_entries = match &src.skills {
+        SkillsField::Wildcard(s) if s == "*" => {
+            let entries: Vec<_> = state
+                .skills
+                .values()
+                .filter(|entry| entry.source == src.source)
+                .collect();
+            if entries.is_empty()
+                || !entries
+                    .iter()
+                    .all(|entry| can_skip_entry(entry, current_revision))
+            {
+                return false;
+            }
+            entries
+        }
+        SkillsField::List(items) => {
+            let mut names = Vec::new();
+            for item in items {
+                let name = skill_target_name(item);
+                if !names.contains(&name) {
+                    names.push(name);
+                }
+            }
+
+            let mut entries = Vec::new();
+            for name in names {
+                let key = format!("{}::{}", src.source, name);
+                let Some(entry) = state.skills.get(&key) else {
+                    return false;
+                };
+                if entry.source != src.source || !can_skip_entry(entry, current_revision) {
+                    return false;
+                }
+                entries.push(entry);
+            }
+            entries
+        }
+        _ => return false,
+    };
+
+    for entry in selected_entries {
+        desired_keys.insert(format!("{}::{}", entry.source, entry.skill));
+        summary.unchanged += 1;
+        actions.push(Action {
+            source: Some(entry.source.clone()),
+            skill: Some(entry.skill.clone()),
+            status: "unchanged".into(),
+            error: None,
+        });
+    }
+    true
+}
+
+fn skill_target_name(target: &SkillTarget) -> &str {
+    match target {
+        SkillTarget::Name(name) => name,
+        SkillTarget::Obj { name, .. } => name,
+    }
+}
+
+fn can_skip_entry(entry: &SkillEntry, current_revision: &str) -> bool {
+    entry.source_revision == current_revision && Path::new(&entry.destination).exists()
 }
 
 fn record_broken_skills(
@@ -104,8 +204,32 @@ fn process_single_skill(
     with_spinner(ctx.animate, ctx.plain, label, || {
         let key = format!("{source}::{skill_name}");
         desired_keys.insert(key.clone());
-        let hash = hash_dir(skill_path)?;
         let dest = destination.join(skill_name);
+
+        let is_unchanged_by_revision = can_skip_source_revision(source_revision)
+            && state
+                .skills
+                .get(&key)
+                .map(|prev| prev.source_revision == source_revision && dest.exists())
+                .unwrap_or(false);
+
+        if is_unchanged_by_revision {
+            if !ctx.dry_run {
+                if let Some(entry) = state.skills.get_mut(&key) {
+                    entry.description = profile_description.clone();
+                }
+            }
+            summary.unchanged += 1;
+            actions.push(Action {
+                source: Some(source.to_string()),
+                skill: Some(skill_name.to_string()),
+                status: "unchanged".into(),
+                error: None,
+            });
+            return Ok(());
+        }
+
+        let hash = hash_dir(skill_path)?;
 
         let is_unchanged = state
             .skills
@@ -179,6 +303,10 @@ fn process_single_skill(
     })
 }
 
+fn can_skip_source_revision(source_revision: &str) -> bool {
+    source_revision != "local" && source_revision != UNKNOWN_REMOTE_REVISION
+}
+
 fn remove_stale_skills(
     ctx: &SyncContext,
     state: &mut State,
@@ -212,5 +340,120 @@ fn remove_stale_skills(
                 });
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source_spec(source: &str, skills: SkillsField) -> SourceSpec {
+        SourceSpec {
+            source: source.to_string(),
+            branch: None,
+            git_ref: None,
+            sub_dir: None,
+            skills,
+        }
+    }
+
+    fn skill_entry(source: &str, skill: &str, revision: &str, destination: &Path) -> SkillEntry {
+        SkillEntry {
+            destination: destination.to_string_lossy().to_string(),
+            hash: String::new(),
+            skill: skill.to_string(),
+            description: String::new(),
+            source: source.to_string(),
+            source_revision: revision.to_string(),
+            updated_at: String::new(),
+            scope: None,
+        }
+    }
+
+    #[test]
+    fn unchanged_source_list_selection_marks_only_requested_skills() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = "https://example.test/skills";
+        let revision = "branch:main@example-skills-abc123";
+        let old_dest = temp.path().join("old");
+        let new_dest = temp.path().join("new");
+        std::fs::create_dir_all(&old_dest).unwrap();
+        std::fs::create_dir_all(&new_dest).unwrap();
+
+        let mut state = State::default();
+        state.skills.insert(
+            format!("{source}::old"),
+            skill_entry(source, "old", revision, &old_dest),
+        );
+        state.skills.insert(
+            format!("{source}::new"),
+            skill_entry(source, "new", revision, &new_dest),
+        );
+        let src = source_spec(
+            source,
+            SkillsField::List(vec![SkillTarget::Name("new".to_string())]),
+        );
+        let mut desired_keys = HashSet::new();
+        let mut summary = Summary::default();
+        let mut actions = Vec::new();
+
+        assert!(record_unchanged_source_selection(
+            &src,
+            revision,
+            &state,
+            &mut desired_keys,
+            &mut summary,
+            &mut actions,
+        ));
+
+        assert_eq!(summary.unchanged, 1);
+        assert!(desired_keys.contains(&format!("{source}::new")));
+        assert!(!desired_keys.contains(&format!("{source}::old")));
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].skill.as_deref(), Some("new"));
+    }
+
+    #[test]
+    fn unchanged_source_list_selection_requires_requested_skill() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = "https://example.test/skills";
+        let revision = "branch:main@example-skills-abc123";
+        let old_dest = temp.path().join("old");
+        std::fs::create_dir_all(&old_dest).unwrap();
+
+        let mut state = State::default();
+        state.skills.insert(
+            format!("{source}::old"),
+            skill_entry(source, "old", revision, &old_dest),
+        );
+        let src = source_spec(
+            source,
+            SkillsField::List(vec![SkillTarget::Name("new".to_string())]),
+        );
+        let mut desired_keys = HashSet::new();
+        let mut summary = Summary::default();
+        let mut actions = Vec::new();
+
+        assert!(!record_unchanged_source_selection(
+            &src,
+            revision,
+            &state,
+            &mut desired_keys,
+            &mut summary,
+            &mut actions,
+        ));
+
+        assert!(desired_keys.is_empty());
+        assert_eq!(summary.unchanged, 0);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn unknown_remote_revision_does_not_enable_revision_skip() {
+        assert!(!can_skip_source_revision(UNKNOWN_REMOTE_REVISION));
+        assert!(!can_skip_source_revision("local"));
+        assert!(can_skip_source_revision(
+            "branch:main@example-skills-abc123"
+        ));
     }
 }

--- a/src/fsops/mod.rs
+++ b/src/fsops/mod.rs
@@ -260,8 +260,7 @@ mod tests {
             SkillTarget::Name("missing".to_string()),
         ]);
 
-        let (targets, broken) =
-            select_targets(&sf, &available, Path::new("/tmp")).expect("select");
+        let (targets, broken) = select_targets(&sf, &available, Path::new("/tmp")).expect("select");
         assert_eq!(targets.len(), 1);
         assert_eq!(targets[0].0, "present");
         assert_eq!(broken.len(), 1);
@@ -287,8 +286,7 @@ mod tests {
             path: Some(nested.to_string_lossy().to_string()),
         }]);
 
-        let (targets, broken) =
-            select_targets(&sf, &available, Path::new("/tmp")).expect("select");
+        let (targets, broken) = select_targets(&sf, &available, Path::new("/tmp")).expect("select");
         assert!(broken.is_empty());
         assert_eq!(targets.len(), 1);
         assert_eq!(targets[0].0, "custom-skill");

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -16,6 +16,8 @@ use crate::error::{err, Result};
 use crate::fsops::resolve_path;
 use crate::model::{GitPin, SourceSpec};
 
+pub(crate) const UNKNOWN_REMOTE_REVISION: &str = "remote:unknown";
+
 fn repo_name_hint(parsed: &parse::RepoUrl) -> String {
     match parsed {
         parse::RepoUrl::GitHub { repo, .. } => repo.clone(),
@@ -68,6 +70,17 @@ fn resolve_source_root(base_root: &Path, sub_dir: Option<&str>) -> Result<PathBu
     Ok(resolved)
 }
 
+/// For remote sources, resolves the current remote revision without downloading the archive.
+/// Returns `None` for local sources, unsupported providers, or API failures (caller falls back to download).
+pub(crate) fn resolve_source_revision(src: &SourceSpec) -> Option<String> {
+    if !src.source.contains("://") {
+        return None;
+    }
+    let parsed = parse::parse_repo_url(&src.source).ok()?;
+    let pin = src.git_pin();
+    remote::resolve_remote_revision(&parsed, &pin)
+}
+
 pub(crate) fn materialize_source(
     src: &SourceSpec,
     cfg_dir: &Path,
@@ -81,22 +94,28 @@ pub(crate) fn materialize_source(
             GitPin::Ref(r) => {
                 let (url, auth) = remote::remote_repo_archive_ref(&parsed, r);
                 remote::download_extract(&url, &auth, stage, &src.source)?;
-                format!("ref:{r}")
+                remote::resolve_remote_revision(&parsed, &pin)
+                    .unwrap_or_else(|| UNKNOWN_REMOTE_REVISION.to_string())
             }
             GitPin::Branch(b) => {
                 let (url, auth) = remote::remote_repo_archive_branch(&parsed, b);
                 remote::download_extract(&url, &auth, stage, &src.source)?;
-                format!("branch:{b}")
+                remote::resolve_remote_revision(&parsed, &pin)
+                    .unwrap_or_else(|| UNKNOWN_REMOTE_REVISION.to_string())
             }
             GitPin::Default => {
                 let (url, auth) = remote::remote_repo_archive_branch(&parsed, "main");
-                remote::download_extract(&url, &auth, stage, &src.source).or_else(|_| {
+                if remote::download_extract(&url, &auth, stage, &src.source).is_err() {
                     let (url, auth) = remote::remote_repo_archive_branch(&parsed, "master");
                     remote::download_extract(&url, &auth, stage, &src.source).map_err(|e2| {
                         err(format!("{e2} (also tried branch `master` after `main`)"))
-                    })
-                })?;
-                "branch:main".into()
+                    })?;
+                    remote::resolve_remote_revision(&parsed, &GitPin::Branch("master".to_string()))
+                        .unwrap_or_else(|| UNKNOWN_REMOTE_REVISION.to_string())
+                } else {
+                    remote::resolve_remote_revision(&parsed, &GitPin::Branch("main".to_string()))
+                        .unwrap_or_else(|| UNKNOWN_REMOTE_REVISION.to_string())
+                }
             }
         };
 

--- a/src/source/remote.rs
+++ b/src/source/remote.rs
@@ -8,6 +8,7 @@ use crate::fsops::http_client;
 
 use super::auth::{auth_env_inline_help, http_fetch_auth_hint, UrlRequestAuth};
 use super::parse::RepoUrl;
+use crate::model::GitPin;
 
 /// Build archive URL for a branch name (uses `refs/heads/` prefix for GitHub).
 pub(super) fn remote_repo_archive_branch(
@@ -215,7 +216,7 @@ pub(super) fn download_extract(
     auth: &UrlRequestAuth,
     dst: &Path,
     user_source: &str,
-) -> Result<()> {
+) -> Result<String> {
     if dst.exists() {
         fs::remove_dir_all(dst)?;
     }
@@ -244,10 +245,16 @@ pub(super) fn download_extract(
     }
     let gz = flate2::read::GzDecoder::new(body.as_ref());
     let mut archive = tar::Archive::new(gz);
+    let mut archive_root = None;
     for entry in archive.entries()? {
         let mut entry = entry?;
         let p = entry.path()?;
         let parts: Vec<_> = p.components().collect();
+        if archive_root.is_none() {
+            archive_root = parts
+                .first()
+                .map(|component| component.as_os_str().to_string_lossy().to_string());
+        }
         if parts.len() < 2 {
             continue;
         }
@@ -265,7 +272,142 @@ pub(super) fn download_extract(
         }
         entry.unpack(target)?;
     }
-    Ok(())
+    Ok(archive_root.unwrap_or_else(|| "unknown".to_string()))
+}
+
+fn archive_root_name(parsed: &RepoUrl, sha: &str) -> String {
+    match parsed {
+        RepoUrl::GitHub { owner, repo, .. } => format!("{owner}-{repo}-{sha}"),
+        RepoUrl::Gitea { owner, repo, .. } => format!("{owner}-{repo}-{sha}"),
+        RepoUrl::Bitbucket {
+            workspace,
+            repo_slug,
+            ..
+        } => {
+            format!("{workspace}-{repo_slug}-{sha}")
+        }
+        RepoUrl::GitLab { project_path, .. } => {
+            let slug = project_path.replace('/', "-");
+            format!("{slug}-{sha}")
+        }
+    }
+}
+
+fn fetch_json_field(url: &str, auth: &UrlRequestAuth, field_path: &[&str]) -> Option<String> {
+    let client = http_client().ok()?;
+    let request = client.get(url);
+    let request = auth.apply(request);
+    let response = request.send().ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let text = response.text().ok()?;
+    let value: serde_json::Value = serde_json::from_str(&text).ok()?;
+    let mut current = &value;
+    for field in field_path {
+        current = current.get(field)?;
+    }
+    current.as_str().map(String::from)
+}
+
+fn resolve_branch_sha(parsed: &RepoUrl, branch: &str) -> Option<String> {
+    match parsed {
+        RepoUrl::GitHub { host, owner, repo } => {
+            let api_host = if host == "github.com" {
+                "api.github.com"
+            } else {
+                host
+            };
+            let url = format!("https://{api_host}/repos/{owner}/{repo}/branches/{branch}");
+            let auth = UrlRequestAuth::for_github_archive();
+            fetch_json_field(&url, &auth, &["commit", "sha"])
+        }
+        RepoUrl::GitLab { host, project_path } => {
+            let encoded = project_path.replace('/', "%2F");
+            let url =
+                format!("https://{host}/api/v4/projects/{encoded}/repository/branches/{branch}");
+            let auth = UrlRequestAuth::for_gitlab_archive();
+            fetch_json_field(&url, &auth, &["commit", "id"])
+        }
+        RepoUrl::Bitbucket {
+            workspace,
+            repo_slug,
+        } => {
+            let url = format!(
+                "https://api.bitbucket.org/2.0/repositories/{workspace}/{repo_slug}/refs/branches/{branch}"
+            );
+            let auth = UrlRequestAuth::for_bitbucket_archive();
+            fetch_json_field(&url, &auth, &["target", "hash"])
+        }
+        RepoUrl::Gitea { host, owner, repo } => {
+            let url = format!("https://{host}/api/v1/repos/{owner}/{repo}/branches/{branch}");
+            let auth = UrlRequestAuth::for_gitea_archive();
+            fetch_json_field(&url, &auth, &["commit", "id"])
+        }
+    }
+}
+
+fn resolve_ref_sha(parsed: &RepoUrl, git_ref: &str) -> Option<String> {
+    match parsed {
+        RepoUrl::GitHub { host, owner, repo } => {
+            let api_host = if host == "github.com" {
+                "api.github.com"
+            } else {
+                host
+            };
+            let url = format!("https://{api_host}/repos/{owner}/{repo}/git/ref/{git_ref}");
+            let auth = UrlRequestAuth::for_github_archive();
+            fetch_json_field(&url, &auth, &["object", "sha"])
+        }
+        RepoUrl::GitLab { host, project_path } => {
+            let encoded = project_path.replace('/', "%2F");
+            let url =
+                format!("https://{host}/api/v4/projects/{encoded}/repository/commits/{git_ref}");
+            let auth = UrlRequestAuth::for_gitlab_archive();
+            fetch_json_field(&url, &auth, &["id"])
+        }
+        RepoUrl::Bitbucket {
+            workspace,
+            repo_slug,
+        } => {
+            let url = format!(
+                "https://api.bitbucket.org/2.0/repositories/{workspace}/{repo_slug}/commit/{git_ref}"
+            );
+            let auth = UrlRequestAuth::for_bitbucket_archive();
+            fetch_json_field(&url, &auth, &["hash"])
+        }
+        RepoUrl::Gitea { host, owner, repo } => {
+            let url = format!("https://{host}/api/v1/repos/{owner}/{repo}/git/commits/{git_ref}");
+            let auth = UrlRequestAuth::for_gitea_archive();
+            fetch_json_field(&url, &auth, &["sha"])
+        }
+    }
+}
+
+/// Resolve the full revision string for a remote ref without downloading the archive.
+/// Returns `branch:{name}@{archive_root}` or `ref:{ref}@{archive_root}`.
+/// Returns `None` if the provider can't be reached or the ref doesn't exist (caller falls back to archive download).
+pub(super) fn resolve_remote_revision(parsed: &RepoUrl, pin: &GitPin) -> Option<String> {
+    let (label, sha) = match pin {
+        GitPin::Ref(r) => {
+            let sha = resolve_ref_sha(parsed, r)?;
+            (format!("ref:{r}"), sha)
+        }
+        GitPin::Branch(b) => {
+            let sha = resolve_branch_sha(parsed, b)?;
+            (format!("branch:{b}"), sha)
+        }
+        GitPin::Default => {
+            if let Some(sha) = resolve_branch_sha(parsed, "main") {
+                ("branch:main".to_string(), sha)
+            } else {
+                let sha = resolve_branch_sha(parsed, "master")?;
+                ("branch:master".to_string(), sha)
+            }
+        }
+    };
+    let root = archive_root_name(parsed, &sha);
+    Some(format!("{label}@{root}"))
 }
 
 #[cfg(test)]
@@ -275,6 +417,53 @@ mod tests {
     use super::*;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn archive_root_name_github() {
+        let parsed = RepoUrl::GitHub {
+            host: "github.com".into(),
+            owner: "openai".into(),
+            repo: "skills".into(),
+        };
+        assert_eq!(archive_root_name(&parsed, "abc123"), "openai-skills-abc123");
+    }
+
+    #[test]
+    fn archive_root_name_gitea() {
+        let parsed = RepoUrl::Gitea {
+            host: "codeberg.org".into(),
+            owner: "user".into(),
+            repo: "my-skills".into(),
+        };
+        assert_eq!(
+            archive_root_name(&parsed, "def456"),
+            "user-my-skills-def456"
+        );
+    }
+
+    #[test]
+    fn archive_root_name_bitbucket() {
+        let parsed = RepoUrl::Bitbucket {
+            workspace: "acme".into(),
+            repo_slug: "skill-packs".into(),
+        };
+        assert_eq!(
+            archive_root_name(&parsed, "789ghi"),
+            "acme-skill-packs-789ghi"
+        );
+    }
+
+    #[test]
+    fn archive_root_name_gitlab() {
+        let parsed = RepoUrl::GitLab {
+            host: "gitlab.com".into(),
+            project_path: "group/subgroup/repo".into(),
+        };
+        assert_eq!(
+            archive_root_name(&parsed, "jkl012"),
+            "group-subgroup-repo-jkl012"
+        );
+    }
 
     #[test]
     fn github_branch_archive_uses_refs_heads_prefix_without_token() {


### PR DESCRIPTION
## Summary
- make remote source revisions SHA-based when available and use an explicit unknown sentinel when API revision resolution is unavailable
- prevent source-level fast-skip from masking `skills` selection changes by only skipping when the currently requested selection is fully satisfied
- fix default-branch revision labeling for `main` vs `master` and add regression tests covering selection-aware skips and unknown revision behavior

## Verification
- mise exec -- cargo test