### PR TITLE
docs(readme): mirror the site's sync output mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@
 
 <img alt="kasetto sync output" src="assets/demo.svg" width="100%" />
 
-**About the name** — comes from the Japanese word **カセット** (*kasetto*), cassette. Think of Skills and MCPs as cassettes you plug in, swap out, and share across machines.
+**About the name**
+
+Name comes from the Japanese word **カセット** (*kasetto*) - cassette. Think of Skills, MCPs, commands as cassettes you plug in, swap out, and share across machines.
 
 ## Why Kasetto
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
   A declarative AI agent environment manager, written in Rust.
 </p>
 
-Name comes from the Japanese word **カセット** (*kasetto*) - cassette. Think of Skills and MCPs as cassettes you plug in, swap out, and share across machines.
-
 <img alt="kasetto sync output" src="assets/demo.svg" width="100%" />
+
+**About the name** — comes from the Japanese word **カセット** (*kasetto*), cassette. Think of Skills and MCPs as cassettes you plug in, swap out, and share across machines.
 
 ## Why Kasetto
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@
 
 Name comes from the Japanese word **カセット** (*kasetto*) - cassette. Think of Skills and MCPs as cassettes you plug in, swap out, and share across machines.
 
-<p align="center">
-  <img alt="kasetto sync output" src="assets/sync-demo.svg" width="580" />
-</p>
+<img alt="kasetto sync output" src="assets/demo.svg" width="100%" />
 
 ## Why Kasetto
 

--- a/README.md
+++ b/README.md
@@ -91,37 +91,9 @@ kst sync
 kst sync --config https://example.com/team-skills.yaml
 ```
 
-```text
-❯ kasetto sync
-
-✓ Resolved 5 sources · 16 items
-
-✓ github.com/pivoshenko/pivoshenko.ai
-  ├─ ↑ git-commit              updated
-  ├─ ↑ git-pr-create           updated
-  ├─ ↑ pivoshenko-brand        updated
-  ├─ + command:gsd             added
-  ├─ ✓ git-branch-create       unchanged
-  ├─ ✓ git-branch-sync         unchanged
-  ├─ ✓ git-branches-cleanup    unchanged
-  ├─ ✓ mcp:github.json         unchanged
-  └─ ✓ mcp:vercel.json         unchanged
-✓ github.com/anthropics/skills
-  ├─ ✓ design-thinking         unchanged
-  ├─ ✓ doc-coauthoring         unchanged
-  ├─ ✓ pdf                     unchanged
-  ├─ ✓ pptx                    unchanged
-  └─ ✓ skill-creator           unchanged
-✓ github.com/vercel-labs/agent-skills
-  ├─ ✓ deploy-to-vercel        unchanged
-  └─ ↑ web-design-guidelines   updated
-✓ github.com/apollographql/skills
-  └─ + rust-best-practices     added
-✓ github.com/mattpocock/skills
-  └─ − grill-me                removed
-
-  ● 4 updated  ● 2 added  ● 1 removed  ● 9 unchanged
-```
+<p align="center">
+  <img alt="kasetto sync output" src="assets/sync-demo.svg" width="580" />
+</p>
 
 Want bare `kst sync` to always pull from a remote URL? Persist it in `~/.config/kasetto/config.yaml`:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@
 
 Name comes from the Japanese word **カセット** (*kasetto*) - cassette. Think of Skills and MCPs as cassettes you plug in, swap out, and share across machines.
 
+<p align="center">
+  <img alt="kasetto sync output" src="assets/sync-demo.svg" width="580" />
+</p>
+
 ## Why Kasetto
 
 There are good tools in this space already - [Vercel Skills](https://github.com/vercel-labs/skills) installs skills from a curated catalog, and [Claude Plugins](https://claude.com/plugins) offer runtime integrations. Both work well for one-off installs, but neither gives you a declarative, version-controlled config.
@@ -90,10 +94,6 @@ kst sync
 # or point at a shared team config over HTTPS
 kst sync --config https://example.com/team-skills.yaml
 ```
-
-<p align="center">
-  <img alt="kasetto sync output" src="assets/sync-demo.svg" width="580" />
-</p>
 
 Want bare `kst sync` to always pull from a remote URL? Persist it in `~/.config/kasetto/config.yaml`:
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,38 @@ kst sync
 kst sync --config https://example.com/team-skills.yaml
 ```
 
+```text
+❯ kasetto sync
+
+✓ Resolved 5 sources · 16 items
+
+✓ github.com/pivoshenko/pivoshenko.ai
+  ├─ ↑ git-commit              updated
+  ├─ ↑ git-pr-create           updated
+  ├─ ↑ pivoshenko-brand        updated
+  ├─ + command:gsd             added
+  ├─ ✓ git-branch-create       unchanged
+  ├─ ✓ git-branch-sync         unchanged
+  ├─ ✓ git-branches-cleanup    unchanged
+  ├─ ✓ mcp:github.json         unchanged
+  └─ ✓ mcp:vercel.json         unchanged
+✓ github.com/anthropics/skills
+  ├─ ✓ design-thinking         unchanged
+  ├─ ✓ doc-coauthoring         unchanged
+  ├─ ✓ pdf                     unchanged
+  ├─ ✓ pptx                    unchanged
+  └─ ✓ skill-creator           unchanged
+✓ github.com/vercel-labs/agent-skills
+  ├─ ✓ deploy-to-vercel        unchanged
+  └─ ↑ web-design-guidelines   updated
+✓ github.com/apollographql/skills
+  └─ + rust-best-practices     added
+✓ github.com/mattpocock/skills
+  └─ − grill-me                removed
+
+  ● 4 updated  ● 2 added  ● 1 removed  ● 9 unchanged
+```
+
 Want bare `kst sync` to always pull from a remote URL? Persist it in `~/.config/kasetto/config.yaml`:
 
 ```yaml

--- a/assets/demo.svg
+++ b/assets/demo.svg
@@ -8,10 +8,9 @@
 
   Animation phases:
     0.10s         ❯ kasetto sync          (prompt types)
-    0.30 → 0.90s  resolving spinner       (5 braille frames cycle)
-    0.90s         ✓ Resolved …            (replaces spinner)
-    1.05 → 3.20s  source tree fills in    (per-row reveal)
-    3.20s         chip strip totals
+    0.40s         ✓ Resolved …            (lands)
+    0.70 → 3.10s  source tree fills in    (per-row reveal)
+    3.10s         chip strip totals
     6.50 → 7.00s  fade out, restart
 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 580 452" width="100%" preserveAspectRatio="xMidYMid meet" font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace" font-size="13">
@@ -33,110 +32,93 @@
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.014;0.029;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
-    <!-- resolving spinner: 5 braille frames cycle at y=98, replaced by ✓ Resolved at 0.9s -->
-    <text x="20" y="88" opacity="0"><tspan fill="#e8a94d">⠋</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.043;0.046;0.057;0.060;1" dur="7s" repeatCount="indefinite"/>
-    </text>
-    <text x="20" y="88" opacity="0"><tspan fill="#e8a94d">⠙</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.060;0.063;0.074;0.077;1" dur="7s" repeatCount="indefinite"/>
-    </text>
-    <text x="20" y="88" opacity="0"><tspan fill="#e8a94d">⠹</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.077;0.080;0.091;0.094;1" dur="7s" repeatCount="indefinite"/>
-    </text>
-    <text x="20" y="88" opacity="0"><tspan fill="#e8a94d">⠸</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.094;0.097;0.108;0.111;1" dur="7s" repeatCount="indefinite"/>
-    </text>
-    <text x="20" y="88" opacity="0"><tspan fill="#e8a94d">⠼</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.111;0.114;0.126;0.129;1" dur="7s" repeatCount="indefinite"/>
-    </text>
-
     <!-- Resolved -->
     <text x="20" y="88" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">Resolved </tspan><tspan fill="#e8a94d">5 sources</tspan><tspan fill="#a8a195"> · 18 items</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.129;0.143;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.057;0.071;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 1 -->
     <text x="20" y="110" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/pivoshenko/pivoshenko.ai</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.150;0.164;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.100;0.114;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="124" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">git-commit</tspan><tspan fill="#a8a195">              updated</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.161;0.175;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.111;0.125;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="138" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">git-pr-create</tspan><tspan fill="#a8a195">           updated</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.173;0.187;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.123;0.137;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="152" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">pivoshenko-brand</tspan><tspan fill="#a8a195">        updated</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.184;0.199;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.134;0.149;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="166" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">+</tspan> <tspan fill="#e4e2de">command:gsd</tspan><tspan fill="#a8a195">             added</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.196;0.210;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.146;0.160;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="180" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branch-create</tspan><tspan fill="#a8a195">       unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.207;0.221;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.157;0.171;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="194" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branch-sync</tspan><tspan fill="#a8a195">         unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.219;0.233;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.169;0.183;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="208" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branches-cleanup</tspan><tspan fill="#a8a195">    unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.230;0.244;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.180;0.194;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="222" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">mcp:github.json</tspan><tspan fill="#a8a195">         unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.241;0.256;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.191;0.206;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="236" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">mcp:vercel.json</tspan><tspan fill="#a8a195">         unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.253;0.267;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.203;0.217;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 2 -->
     <text x="20" y="250" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/anthropics/skills</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.271;0.286;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.221;0.236;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="264" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">design-thinking</tspan><tspan fill="#a8a195">         unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.283;0.297;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.233;0.247;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="278" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">doc-coauthoring</tspan><tspan fill="#a8a195">         unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.294;0.309;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.244;0.259;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="292" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">pdf</tspan><tspan fill="#a8a195">                     unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.306;0.320;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.256;0.270;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="306" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">pptx</tspan><tspan fill="#a8a195">                    unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.317;0.331;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.267;0.281;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="320" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">skill-creator</tspan><tspan fill="#a8a195">           unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.329;0.343;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.279;0.293;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 3 -->
     <text x="20" y="334" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/vercel-labs/agent-skills</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.347;0.361;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.300;0.314;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="348" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">deploy-to-vercel</tspan><tspan fill="#a8a195">        unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.359;0.373;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.311;0.326;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="362" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">web-design-guidelines</tspan><tspan fill="#a8a195">   updated</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.370;0.384;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.323;0.337;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 4 -->
     <text x="20" y="376" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/apollographql/skills</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.389;0.403;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.343;0.357;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="390" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">+</tspan> <tspan fill="#e4e2de">rust-best-practices</tspan><tspan fill="#a8a195">     added</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.400;0.414;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.354;0.369;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 5 -->
     <text x="20" y="404" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/mattpocock/skills</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.419;0.433;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.371;0.386;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="418" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#e87e6c">−</tspan> <tspan fill="#e4e2de">grill-me</tspan><tspan fill="#a8a195">                removed</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.430;0.444;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.383;0.397;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- chip strip -->
     <text x="20" y="434" opacity="0"><tspan>  </tspan><tspan fill="#e8a94d">●</tspan><tspan fill="#e4e2de"> 4 </tspan><tspan fill="#a8a195">updated  </tspan><tspan fill="#84c578">●</tspan><tspan fill="#e4e2de"> 2 </tspan><tspan fill="#a8a195">added  </tspan><tspan fill="#e87e6c">●</tspan><tspan fill="#e4e2de"> 1 </tspan><tspan fill="#a8a195">removed  </tspan><tspan fill="#6e6759">●</tspan><tspan fill="#e4e2de"> 11 </tspan><tspan fill="#a8a195">unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.457;0.471;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.414;0.443;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
   </g>

--- a/assets/demo.svg
+++ b/assets/demo.svg
@@ -1,14 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Animated kasetto sync mock — mirrors the hero terminal on kasetto.dev.
-  Palette aligned with `src/colors.rs` (CLI source of truth) and popil
+  Palette aligned with `src/colors.rs` (CLI source of truth) and the popil
   surfaces from `site/app/globals.css`. SMIL animations are sandboxed via
   GitHub's camo proxy when embedded as an <img>; no scripts, no external
   fonts. 7-second loop with line-by-line reveal, hold, then reset.
+
+  Animation phases:
+    0.10s         ❯ kasetto sync          (prompt types)
+    0.30 → 0.90s  resolving spinner       (5 braille frames cycle)
+    0.90s         ✓ Resolved …            (replaces spinner)
+    1.05 → 3.20s  source tree fills in    (per-row reveal)
+    3.20s         chip strip totals
+    6.50 → 7.00s  fade out, restart
 -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 580 580" width="580" height="580" font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace" font-size="13">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 580 560" width="100%" preserveAspectRatio="xMidYMid meet" font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace" font-size="13">
   <!-- frame -->
-  <rect x="0" y="0" width="580" height="580" rx="8" ry="8" fill="#1f1f1e"/>
+  <rect x="0" y="0" width="580" height="560" rx="8" ry="8" fill="#1f1f1e"/>
   <rect x="0" y="0" width="580" height="36" rx="8" ry="8" fill="#1a1a19"/>
   <rect x="0" y="28" width="580" height="8" fill="#1a1a19"/>
   <line x1="0" y1="36" x2="580" y2="36" stroke="#2e2e2c" stroke-width="1"/>
@@ -25,93 +33,110 @@
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.014;0.029;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
+    <!-- resolving spinner: 5 braille frames cycle at y=98, replaced by ✓ Resolved at 0.9s -->
+    <text x="20" y="98" opacity="0"><tspan fill="#e8a94d">⠋</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.043;0.046;0.057;0.060;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="98" opacity="0"><tspan fill="#e8a94d">⠙</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.060;0.063;0.074;0.077;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="98" opacity="0"><tspan fill="#e8a94d">⠹</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.077;0.080;0.091;0.094;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="98" opacity="0"><tspan fill="#e8a94d">⠸</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.094;0.097;0.108;0.111;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="98" opacity="0"><tspan fill="#e8a94d">⠼</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.111;0.114;0.126;0.129;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+
     <!-- Resolved -->
     <text x="20" y="98" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">Resolved </tspan><tspan fill="#e8a94d">5 sources</tspan><tspan fill="#a8a195"> · 18 items</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.057;0.071;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.129;0.143;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 1 -->
     <text x="20" y="128" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/pivoshenko/pivoshenko.ai</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.100;0.114;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.150;0.164;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="146" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">git-commit</tspan><tspan fill="#a8a195">              updated</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.111;0.125;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.161;0.175;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="164" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">git-pr-create</tspan><tspan fill="#a8a195">           updated</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.123;0.137;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.173;0.187;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="182" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">pivoshenko-brand</tspan><tspan fill="#a8a195">        updated</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.134;0.149;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.184;0.199;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="200" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">+</tspan> <tspan fill="#e4e2de">command:gsd</tspan><tspan fill="#a8a195">             added</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.146;0.160;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.196;0.210;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="218" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branch-create</tspan><tspan fill="#a8a195">       unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.157;0.171;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.207;0.221;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="236" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branch-sync</tspan><tspan fill="#a8a195">         unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.169;0.183;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.219;0.233;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="254" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branches-cleanup</tspan><tspan fill="#a8a195">    unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.180;0.194;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.230;0.244;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="272" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">mcp:github.json</tspan><tspan fill="#a8a195">         unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.191;0.206;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.241;0.256;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="290" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">mcp:vercel.json</tspan><tspan fill="#a8a195">         unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.203;0.217;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.253;0.267;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 2 -->
     <text x="20" y="308" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/anthropics/skills</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.221;0.236;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.271;0.286;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="326" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">design-thinking</tspan><tspan fill="#a8a195">         unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.233;0.247;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.283;0.297;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="344" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">doc-coauthoring</tspan><tspan fill="#a8a195">         unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.244;0.259;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.294;0.309;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="362" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">pdf</tspan><tspan fill="#a8a195">                     unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.256;0.270;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.306;0.320;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="380" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">pptx</tspan><tspan fill="#a8a195">                    unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.267;0.281;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.317;0.331;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="398" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">skill-creator</tspan><tspan fill="#a8a195">           unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.279;0.293;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.329;0.343;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 3 -->
     <text x="20" y="416" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/vercel-labs/agent-skills</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.300;0.314;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.347;0.361;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="434" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">deploy-to-vercel</tspan><tspan fill="#a8a195">        unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.311;0.326;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.359;0.373;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="452" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">web-design-guidelines</tspan><tspan fill="#a8a195">   updated</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.323;0.337;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.370;0.384;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 4 -->
     <text x="20" y="470" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/apollographql/skills</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.343;0.357;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.389;0.403;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="488" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">+</tspan> <tspan fill="#e4e2de">rust-best-practices</tspan><tspan fill="#a8a195">     added</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.354;0.369;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.400;0.414;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 5 -->
     <text x="20" y="506" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/mattpocock/skills</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.371;0.386;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.419;0.433;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
     <text x="20" y="524" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#e87e6c">−</tspan> <tspan fill="#e4e2de">grill-me</tspan><tspan fill="#a8a195">                removed</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.383;0.397;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.430;0.444;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- chip strip -->
     <text x="20" y="546" opacity="0"><tspan>  </tspan><tspan fill="#e8a94d">●</tspan><tspan fill="#e4e2de"> 4 </tspan><tspan fill="#a8a195">updated  </tspan><tspan fill="#84c578">●</tspan><tspan fill="#e4e2de"> 2 </tspan><tspan fill="#a8a195">added  </tspan><tspan fill="#e87e6c">●</tspan><tspan fill="#e4e2de"> 1 </tspan><tspan fill="#a8a195">removed  </tspan><tspan fill="#6e6759">●</tspan><tspan fill="#e4e2de"> 11 </tspan><tspan fill="#a8a195">unchanged</tspan>
-      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.414;0.443;0.93;1" dur="7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.457;0.471;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
   </g>

--- a/assets/demo.svg
+++ b/assets/demo.svg
@@ -14,9 +14,9 @@
     3.20s         chip strip totals
     6.50 → 7.00s  fade out, restart
 -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 580 560" width="100%" preserveAspectRatio="xMidYMid meet" font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace" font-size="13">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 580 452" width="100%" preserveAspectRatio="xMidYMid meet" font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace" font-size="13">
   <!-- frame -->
-  <rect x="0" y="0" width="580" height="560" rx="8" ry="8" fill="#1f1f1e"/>
+  <rect x="0" y="0" width="580" height="452" rx="8" ry="8" fill="#1f1f1e"/>
   <rect x="0" y="0" width="580" height="36" rx="8" ry="8" fill="#1a1a19"/>
   <rect x="0" y="28" width="580" height="8" fill="#1a1a19"/>
   <line x1="0" y1="36" x2="580" y2="36" stroke="#2e2e2c" stroke-width="1"/>
@@ -29,113 +29,113 @@
   <g xml:space="preserve" fill="#e4e2de">
 
     <!-- prompt -->
-    <text x="20" y="64" opacity="0"><tspan fill="#e8a94d">❯</tspan> <tspan fill="#e4e2de">kasetto </tspan><tspan fill="#e8a94d">sync</tspan>
+    <text x="20" y="60" opacity="0"><tspan fill="#e8a94d">❯</tspan> <tspan fill="#e4e2de">kasetto </tspan><tspan fill="#e8a94d">sync</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.014;0.029;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- resolving spinner: 5 braille frames cycle at y=98, replaced by ✓ Resolved at 0.9s -->
-    <text x="20" y="98" opacity="0"><tspan fill="#e8a94d">⠋</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
+    <text x="20" y="88" opacity="0"><tspan fill="#e8a94d">⠋</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.043;0.046;0.057;0.060;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="98" opacity="0"><tspan fill="#e8a94d">⠙</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
+    <text x="20" y="88" opacity="0"><tspan fill="#e8a94d">⠙</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.060;0.063;0.074;0.077;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="98" opacity="0"><tspan fill="#e8a94d">⠹</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
+    <text x="20" y="88" opacity="0"><tspan fill="#e8a94d">⠹</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.077;0.080;0.091;0.094;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="98" opacity="0"><tspan fill="#e8a94d">⠸</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
+    <text x="20" y="88" opacity="0"><tspan fill="#e8a94d">⠸</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.094;0.097;0.108;0.111;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="98" opacity="0"><tspan fill="#e8a94d">⠼</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
+    <text x="20" y="88" opacity="0"><tspan fill="#e8a94d">⠼</tspan> <tspan fill="#e4e2de">Resolving sources</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.111;0.114;0.126;0.129;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- Resolved -->
-    <text x="20" y="98" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">Resolved </tspan><tspan fill="#e8a94d">5 sources</tspan><tspan fill="#a8a195"> · 18 items</tspan>
+    <text x="20" y="88" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">Resolved </tspan><tspan fill="#e8a94d">5 sources</tspan><tspan fill="#a8a195"> · 18 items</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.129;0.143;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 1 -->
-    <text x="20" y="128" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/pivoshenko/pivoshenko.ai</tspan>
+    <text x="20" y="110" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/pivoshenko/pivoshenko.ai</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.150;0.164;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="146" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">git-commit</tspan><tspan fill="#a8a195">              updated</tspan>
+    <text x="20" y="124" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">git-commit</tspan><tspan fill="#a8a195">              updated</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.161;0.175;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="164" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">git-pr-create</tspan><tspan fill="#a8a195">           updated</tspan>
+    <text x="20" y="138" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">git-pr-create</tspan><tspan fill="#a8a195">           updated</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.173;0.187;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="182" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">pivoshenko-brand</tspan><tspan fill="#a8a195">        updated</tspan>
+    <text x="20" y="152" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">pivoshenko-brand</tspan><tspan fill="#a8a195">        updated</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.184;0.199;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="200" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">+</tspan> <tspan fill="#e4e2de">command:gsd</tspan><tspan fill="#a8a195">             added</tspan>
+    <text x="20" y="166" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">+</tspan> <tspan fill="#e4e2de">command:gsd</tspan><tspan fill="#a8a195">             added</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.196;0.210;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="218" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branch-create</tspan><tspan fill="#a8a195">       unchanged</tspan>
+    <text x="20" y="180" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branch-create</tspan><tspan fill="#a8a195">       unchanged</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.207;0.221;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="236" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branch-sync</tspan><tspan fill="#a8a195">         unchanged</tspan>
+    <text x="20" y="194" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branch-sync</tspan><tspan fill="#a8a195">         unchanged</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.219;0.233;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="254" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branches-cleanup</tspan><tspan fill="#a8a195">    unchanged</tspan>
+    <text x="20" y="208" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branches-cleanup</tspan><tspan fill="#a8a195">    unchanged</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.230;0.244;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="272" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">mcp:github.json</tspan><tspan fill="#a8a195">         unchanged</tspan>
+    <text x="20" y="222" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">mcp:github.json</tspan><tspan fill="#a8a195">         unchanged</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.241;0.256;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="290" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">mcp:vercel.json</tspan><tspan fill="#a8a195">         unchanged</tspan>
+    <text x="20" y="236" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">mcp:vercel.json</tspan><tspan fill="#a8a195">         unchanged</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.253;0.267;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 2 -->
-    <text x="20" y="308" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/anthropics/skills</tspan>
+    <text x="20" y="250" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/anthropics/skills</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.271;0.286;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="326" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">design-thinking</tspan><tspan fill="#a8a195">         unchanged</tspan>
+    <text x="20" y="264" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">design-thinking</tspan><tspan fill="#a8a195">         unchanged</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.283;0.297;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="344" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">doc-coauthoring</tspan><tspan fill="#a8a195">         unchanged</tspan>
+    <text x="20" y="278" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">doc-coauthoring</tspan><tspan fill="#a8a195">         unchanged</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.294;0.309;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="362" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">pdf</tspan><tspan fill="#a8a195">                     unchanged</tspan>
+    <text x="20" y="292" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">pdf</tspan><tspan fill="#a8a195">                     unchanged</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.306;0.320;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="380" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">pptx</tspan><tspan fill="#a8a195">                    unchanged</tspan>
+    <text x="20" y="306" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">pptx</tspan><tspan fill="#a8a195">                    unchanged</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.317;0.331;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="398" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">skill-creator</tspan><tspan fill="#a8a195">           unchanged</tspan>
+    <text x="20" y="320" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">skill-creator</tspan><tspan fill="#a8a195">           unchanged</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.329;0.343;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 3 -->
-    <text x="20" y="416" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/vercel-labs/agent-skills</tspan>
+    <text x="20" y="334" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/vercel-labs/agent-skills</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.347;0.361;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="434" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">deploy-to-vercel</tspan><tspan fill="#a8a195">        unchanged</tspan>
+    <text x="20" y="348" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">deploy-to-vercel</tspan><tspan fill="#a8a195">        unchanged</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.359;0.373;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="452" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">web-design-guidelines</tspan><tspan fill="#a8a195">   updated</tspan>
+    <text x="20" y="362" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">web-design-guidelines</tspan><tspan fill="#a8a195">   updated</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.370;0.384;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 4 -->
-    <text x="20" y="470" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/apollographql/skills</tspan>
+    <text x="20" y="376" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/apollographql/skills</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.389;0.403;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="488" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">+</tspan> <tspan fill="#e4e2de">rust-best-practices</tspan><tspan fill="#a8a195">     added</tspan>
+    <text x="20" y="390" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">+</tspan> <tspan fill="#e4e2de">rust-best-practices</tspan><tspan fill="#a8a195">     added</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.400;0.414;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- source 5 -->
-    <text x="20" y="506" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/mattpocock/skills</tspan>
+    <text x="20" y="404" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/mattpocock/skills</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.419;0.433;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
-    <text x="20" y="524" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#e87e6c">−</tspan> <tspan fill="#e4e2de">grill-me</tspan><tspan fill="#a8a195">                removed</tspan>
+    <text x="20" y="418" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#e87e6c">−</tspan> <tspan fill="#e4e2de">grill-me</tspan><tspan fill="#a8a195">                removed</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.430;0.444;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
     <!-- chip strip -->
-    <text x="20" y="546" opacity="0"><tspan>  </tspan><tspan fill="#e8a94d">●</tspan><tspan fill="#e4e2de"> 4 </tspan><tspan fill="#a8a195">updated  </tspan><tspan fill="#84c578">●</tspan><tspan fill="#e4e2de"> 2 </tspan><tspan fill="#a8a195">added  </tspan><tspan fill="#e87e6c">●</tspan><tspan fill="#e4e2de"> 1 </tspan><tspan fill="#a8a195">removed  </tspan><tspan fill="#6e6759">●</tspan><tspan fill="#e4e2de"> 11 </tspan><tspan fill="#a8a195">unchanged</tspan>
+    <text x="20" y="434" opacity="0"><tspan>  </tspan><tspan fill="#e8a94d">●</tspan><tspan fill="#e4e2de"> 4 </tspan><tspan fill="#a8a195">updated  </tspan><tspan fill="#84c578">●</tspan><tspan fill="#e4e2de"> 2 </tspan><tspan fill="#a8a195">added  </tspan><tspan fill="#e87e6c">●</tspan><tspan fill="#e4e2de"> 1 </tspan><tspan fill="#a8a195">removed  </tspan><tspan fill="#6e6759">●</tspan><tspan fill="#e4e2de"> 11 </tspan><tspan fill="#a8a195">unchanged</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.457;0.471;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 

--- a/assets/sync-demo.svg
+++ b/assets/sync-demo.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Animated kasetto sync mock — mirrors the hero terminal on kasetto.dev.
+  Palette aligned with `src/colors.rs` (CLI source of truth) and popil
+  surfaces from `site/app/globals.css`. SMIL animations are sandboxed via
+  GitHub's camo proxy when embedded as an <img>; no scripts, no external
+  fonts. 7-second loop with line-by-line reveal, hold, then reset.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 580 580" width="580" height="580" font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace" font-size="13">
+  <!-- frame -->
+  <rect x="0" y="0" width="580" height="580" rx="8" ry="8" fill="#1f1f1e"/>
+  <rect x="0" y="0" width="580" height="36" rx="8" ry="8" fill="#1a1a19"/>
+  <rect x="0" y="28" width="580" height="8" fill="#1a1a19"/>
+  <line x1="0" y1="36" x2="580" y2="36" stroke="#2e2e2c" stroke-width="1"/>
+  <circle cx="16" cy="18" r="5" fill="#373634"/>
+  <circle cx="32" cy="18" r="5" fill="#373634"/>
+  <circle cx="48" cy="18" r="5" fill="#373634"/>
+  <text x="70" y="23" fill="#6e6759" font-size="11" letter-spacing="0.08em">~/dev/kasetto</text>
+
+  <!-- body lines -->
+  <g xml:space="preserve" fill="#e4e2de">
+
+    <!-- prompt -->
+    <text x="20" y="64" opacity="0"><tspan fill="#e8a94d">❯</tspan> <tspan fill="#e4e2de">kasetto </tspan><tspan fill="#e8a94d">sync</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.014;0.029;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+
+    <!-- Resolved -->
+    <text x="20" y="98" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">Resolved </tspan><tspan fill="#e8a94d">5 sources</tspan><tspan fill="#a8a195"> · 16 items</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.057;0.071;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+
+    <!-- source 1 -->
+    <text x="20" y="128" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/pivoshenko/pivoshenko.ai</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.100;0.114;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="146" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">git-commit</tspan><tspan fill="#a8a195">              updated</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.111;0.125;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="164" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">git-pr-create</tspan><tspan fill="#a8a195">           updated</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.123;0.137;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="182" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">pivoshenko-brand</tspan><tspan fill="#a8a195">        updated</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.134;0.149;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="200" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">+</tspan> <tspan fill="#e4e2de">command:gsd</tspan><tspan fill="#a8a195">             added</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.146;0.160;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="218" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branch-create</tspan><tspan fill="#a8a195">       unchanged</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.157;0.171;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="236" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branch-sync</tspan><tspan fill="#a8a195">         unchanged</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.169;0.183;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="254" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">git-branches-cleanup</tspan><tspan fill="#a8a195">    unchanged</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.180;0.194;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="272" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">mcp:github.json</tspan><tspan fill="#a8a195">         unchanged</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.191;0.206;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="290" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">mcp:vercel.json</tspan><tspan fill="#a8a195">         unchanged</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.203;0.217;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+
+    <!-- source 2 -->
+    <text x="20" y="308" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/anthropics/skills</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.221;0.236;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="326" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">design-thinking</tspan><tspan fill="#a8a195">         unchanged</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.233;0.247;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="344" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">doc-coauthoring</tspan><tspan fill="#a8a195">         unchanged</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.244;0.259;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="362" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">pdf</tspan><tspan fill="#a8a195">                     unchanged</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.256;0.270;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="380" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">pptx</tspan><tspan fill="#a8a195">                    unchanged</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.267;0.281;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="398" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">skill-creator</tspan><tspan fill="#a8a195">           unchanged</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.279;0.293;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+
+    <!-- source 3 -->
+    <text x="20" y="416" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/vercel-labs/agent-skills</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.300;0.314;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="434" opacity="0"><tspan fill="#6e6759">  ├─ </tspan><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">deploy-to-vercel</tspan><tspan fill="#a8a195">        unchanged</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.311;0.326;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="452" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#e8a94d">↑</tspan> <tspan fill="#e4e2de">web-design-guidelines</tspan><tspan fill="#a8a195">   updated</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.323;0.337;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+
+    <!-- source 4 -->
+    <text x="20" y="470" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/apollographql/skills</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.343;0.357;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="488" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#84c578">+</tspan> <tspan fill="#e4e2de">rust-best-practices</tspan><tspan fill="#a8a195">     added</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.354;0.369;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+
+    <!-- source 5 -->
+    <text x="20" y="506" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#6cbfd3">github.com/mattpocock/skills</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.371;0.386;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+    <text x="20" y="524" opacity="0"><tspan fill="#6e6759">  └─ </tspan><tspan fill="#e87e6c">−</tspan> <tspan fill="#e4e2de">grill-me</tspan><tspan fill="#a8a195">                removed</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.383;0.397;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+
+    <!-- chip strip -->
+    <text x="20" y="546" opacity="0"><tspan>  </tspan><tspan fill="#e8a94d">●</tspan><tspan fill="#e4e2de"> 4 </tspan><tspan fill="#a8a195">updated  </tspan><tspan fill="#84c578">●</tspan><tspan fill="#e4e2de"> 2 </tspan><tspan fill="#a8a195">added  </tspan><tspan fill="#e87e6c">●</tspan><tspan fill="#e4e2de"> 1 </tspan><tspan fill="#a8a195">removed  </tspan><tspan fill="#6e6759">●</tspan><tspan fill="#e4e2de"> 9 </tspan><tspan fill="#a8a195">unchanged</tspan>
+      <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.414;0.443;0.93;1" dur="7s" repeatCount="indefinite"/>
+    </text>
+
+  </g>
+</svg>

--- a/assets/sync-demo.svg
+++ b/assets/sync-demo.svg
@@ -26,7 +26,7 @@
     </text>
 
     <!-- Resolved -->
-    <text x="20" y="98" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">Resolved </tspan><tspan fill="#e8a94d">5 sources</tspan><tspan fill="#a8a195"> · 16 items</tspan>
+    <text x="20" y="98" opacity="0"><tspan fill="#84c578">✓</tspan> <tspan fill="#e4e2de">Resolved </tspan><tspan fill="#e8a94d">5 sources</tspan><tspan fill="#a8a195"> · 18 items</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.057;0.071;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 
@@ -110,7 +110,7 @@
     </text>
 
     <!-- chip strip -->
-    <text x="20" y="546" opacity="0"><tspan>  </tspan><tspan fill="#e8a94d">●</tspan><tspan fill="#e4e2de"> 4 </tspan><tspan fill="#a8a195">updated  </tspan><tspan fill="#84c578">●</tspan><tspan fill="#e4e2de"> 2 </tspan><tspan fill="#a8a195">added  </tspan><tspan fill="#e87e6c">●</tspan><tspan fill="#e4e2de"> 1 </tspan><tspan fill="#a8a195">removed  </tspan><tspan fill="#6e6759">●</tspan><tspan fill="#e4e2de"> 9 </tspan><tspan fill="#a8a195">unchanged</tspan>
+    <text x="20" y="546" opacity="0"><tspan>  </tspan><tspan fill="#e8a94d">●</tspan><tspan fill="#e4e2de"> 4 </tspan><tspan fill="#a8a195">updated  </tspan><tspan fill="#84c578">●</tspan><tspan fill="#e4e2de"> 2 </tspan><tspan fill="#a8a195">added  </tspan><tspan fill="#e87e6c">●</tspan><tspan fill="#e4e2de"> 1 </tspan><tspan fill="#a8a195">removed  </tspan><tspan fill="#6e6759">●</tspan><tspan fill="#e4e2de"> 11 </tspan><tspan fill="#a8a195">unchanged</tspan>
       <animate attributeName="opacity" values="0;0;1;1;0" keyTimes="0;0.414;0.443;0.93;1" dur="7s" repeatCount="indefinite"/>
     </text>
 


### PR DESCRIPTION
# Pull Request Checklist

## Summary

- Adds a fenced text block right under the `kst sync` example in the README, mirroring the source-grouped tree, per-asset glyphs (`+ ↑ − ✓`), and chip-strip summary that the hero terminal mock on kasetto.dev already shows.
- Pure docs — no code or build changes.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors