### PR TITLE
perf: hash skill destinations once and copy via fs::copy

### DIFF
--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -38,11 +38,7 @@ pub(crate) fn run(
 
     let state = lock.state();
     let mcp_assets = lock.list_tracked_asset_ids("mcp");
-    let command_assets: Vec<(String, String)> = lock
-        .list_tracked_asset_ids("command")
-        .iter()
-        .map(|(id, dest)| (id.to_string(), dest.to_string()))
-        .collect();
+    let command_assets = lock.list_tracked_asset_ids("command");
 
     let skills_count = state.skills.len();
     let mcps_count = mcp_assets.len();
@@ -94,7 +90,7 @@ pub(crate) fn run(
 fn apply_removals(
     state: &State,
     mcp_assets: &[(&str, &str)],
-    command_assets: &[(String, String)],
+    command_assets: &[(&str, &str)],
     scope: Scope,
     project_root: &std::path::Path,
 ) -> Result<()> {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -77,7 +77,7 @@ pub(crate) fn run(
     let installation_path = if install_paths.is_empty() {
         "none".to_string()
     } else if install_paths.len() == 1 {
-        install_paths[0].clone()
+        install_paths.remove(0)
     } else {
         install_paths.join(", ")
     };
@@ -86,7 +86,7 @@ pub(crate) fn run(
     skills.sort();
 
     let failures = runtime.load_latest_failures();
-    let last_sync = runtime.last_run.clone();
+    let last_sync = runtime.last_run;
 
     let managed_mcps = lock.list_installed_mcps();
     let managed_commands = lock.list_installed_commands();
@@ -132,7 +132,7 @@ pub(crate) fn run(
         ("Lock file", relativize_home(&output.lock_file)),
         ("Install path", relativize_home(&output.installation_path)),
         ("Last sync", last_sync_short),
-        ("Updates", update_check_text.clone()),
+        ("Updates", update_check_text),
     ];
     let env_key_w = env_rows.iter().map(|(k, _)| k.len()).max().unwrap_or(0);
     for (k, v) in &env_rows {

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -62,10 +62,7 @@ pub(crate) fn run(opts: &RemoveOptions) -> Result<()> {
         ..Default::default()
     });
     let source = derived.source.clone();
-    let derived_pin = derived
-        .git_ref
-        .as_deref()
-        .or(derived.branch.as_deref());
+    let derived_pin = derived.git_ref.as_deref().or(derived.branch.as_deref());
     let pin = opts
         .git_ref
         .or(opts.branch)

--- a/src/commands/self_update.rs
+++ b/src/commands/self_update.rs
@@ -175,10 +175,10 @@ fn current_target() -> String {
     let arch = std::env::consts::ARCH;
     let os = std::env::consts::OS;
     match (arch, os) {
-        ("aarch64", "macos") => "aarch64-apple-darwin".to_string(),
-        ("x86_64", "macos") => "x86_64-apple-darwin".to_string(),
-        ("x86_64", "linux") => "x86_64-unknown-linux-gnu".to_string(),
-        ("aarch64", "linux") => "aarch64-unknown-linux-gnu".to_string(),
+        ("aarch64", "macos") => "aarch64-apple-darwin".to_owned(),
+        ("x86_64", "macos") => "x86_64-apple-darwin".to_owned(),
+        ("x86_64", "linux") => "x86_64-unknown-linux-gnu".to_owned(),
+        ("aarch64", "linux") => "aarch64-unknown-linux-gnu".to_owned(),
         _ => format!("{arch}-unknown-{os}"),
     }
 }

--- a/src/commands/sync/commands.rs
+++ b/src/commands/sync/commands.rs
@@ -486,16 +486,8 @@ fn remove_stale(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fsops::temp_dir;
     use crate::model::{Agent, AgentField, CommandSourceSpec, CommandsField, Config, Scope};
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn temp_dir(prefix: &str) -> PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        std::env::temp_dir().join(format!("kasetto-{prefix}-{}-{nonce}", std::process::id()))
-    }
 
     fn write(path: &std::path::Path, contents: &str) {
         if let Some(parent) = path.parent() {
@@ -507,14 +499,14 @@ mod tests {
     #[test]
     fn sync_writes_to_supported_agents_and_skips_unsupported() {
         // Source: a local path with one command file.
-        let src_root = temp_dir("src");
+        let src_root = temp_dir("kasetto-src");
         write(
             &src_root.join("commands/git/commit.md"),
             "---\ndescription: commit\n---\nBody $ARGUMENTS\n",
         );
 
         // Project root that doubles as the project scope target for the agents.
-        let project = temp_dir("proj");
+        let project = temp_dir("kasetto-proj");
         fs::create_dir_all(&project).unwrap();
 
         // Pre-existing user file under .claude/commands that must be preserved.
@@ -672,12 +664,12 @@ mod tests {
 
     #[test]
     fn second_run_unchanged_without_source_no_fetch() {
-        let src_root = temp_dir("src");
+        let src_root = temp_dir("kasetto-src");
         write(
             &src_root.join("commands/foo.md"),
             "---\ndescription: foo\n---\nBody\n",
         );
-        let project = temp_dir("proj");
+        let project = temp_dir("kasetto-proj");
         fs::create_dir_all(&project).unwrap();
         let dests = vec![project.clone()];
 
@@ -705,12 +697,12 @@ mod tests {
 
     #[test]
     fn locked_errors_when_command_absent_from_lock() {
-        let src_root = temp_dir("src");
+        let src_root = temp_dir("kasetto-src");
         write(
             &src_root.join("commands/foo.md"),
             "---\ndescription: foo\n---\nBody\n",
         );
-        let project = temp_dir("proj");
+        let project = temp_dir("kasetto-proj");
         fs::create_dir_all(&project).unwrap();
         let dests = vec![project.clone()];
 

--- a/src/commands/sync/commands.rs
+++ b/src/commands/sync/commands.rs
@@ -569,12 +569,8 @@ mod tests {
         assert!(user_file.is_file());
 
         // Lock contains 1 command asset (one source × one command name).
-        let lock_assets: Vec<_> = lock
-            .assets
-            .iter()
-            .filter(|(_, a)| a.kind == "command")
-            .collect();
-        assert_eq!(lock_assets.len(), 1);
+        let lock_assets = lock.assets.values().filter(|a| a.kind == "command").count();
+        assert_eq!(lock_assets, 1);
 
         // Second sync that removes the command (empty commands).
         let cfg2 = Config {

--- a/src/commands/sync/mcps.rs
+++ b/src/commands/sync/mcps.rs
@@ -494,17 +494,19 @@ fn remove_stale(
 ) {
     let existing_mcps: Vec<(String, String)> = lock
         .list_tracked_asset_ids("mcp")
-        .iter()
-        .map(|(id, dest)| (id.to_string(), dest.to_string()))
-        .collect();
-    let servers_by_id: std::collections::HashMap<String, String> =
-        existing_mcps.iter().cloned().collect();
-    let candidates: Vec<StaleEntry> = existing_mcps
         .into_iter()
+        .map(|(id, dest)| (id.to_owned(), dest.to_owned()))
+        .collect();
+    let servers_by_id: std::collections::HashMap<&str, &str> = existing_mcps
+        .iter()
+        .map(|(id, dest)| (id.as_str(), dest.as_str()))
+        .collect();
+    let candidates: Vec<StaleEntry> = existing_mcps
+        .iter()
         .map(|(id, _)| {
-            let mcp_name = id.rsplit("::").next().unwrap_or(&id).to_string();
+            let mcp_name = id.rsplit("::").next().unwrap_or(id);
             StaleEntry {
-                id,
+                id: id.clone(),
                 action_source: None,
                 action_skill: format!("mcp:{mcp_name}"),
             }
@@ -583,9 +585,8 @@ mod tests {
             source_revision: "branch:main".into(),
         }];
 
-        let new_servers: Vec<&PendingMcp> = update_only.iter().filter(|p| p.is_new).collect();
         assert!(
-            new_servers.is_empty(),
+            !update_only.iter().any(|p| p.is_new),
             "updates should not trigger the gate"
         );
     }

--- a/src/commands/sync/mod.rs
+++ b/src/commands/sync/mod.rs
@@ -358,11 +358,11 @@ fn print_sync_tree(report: &Report, plain: bool) {
     // Group actions by source, preserving first-seen order.
     let mut groups: Vec<(String, Vec<&crate::model::Action>)> = Vec::new();
     for a in &report.actions {
-        let src = a.source.clone().unwrap_or_else(|| "-".to_string());
-        if let Some(g) = groups.iter_mut().find(|(k, _)| k == &src) {
+        let src = a.source.as_deref().unwrap_or("-");
+        if let Some(g) = groups.iter_mut().find(|(k, _)| k == src) {
             g.1.push(a);
         } else {
-            groups.push((src, vec![a]));
+            groups.push((src.to_owned(), vec![a]));
         }
     }
 

--- a/src/commands/sync/mod.rs
+++ b/src/commands/sync/mod.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use crate::colors::{ACCENT, ATTENTION, ERROR, RESET, SECONDARY, SUCCESS};
 use crate::error::Result;
-use crate::fsops::{load_config_any, now_iso, now_unix, resolve_destinations, scope_root};
+use crate::fsops::{load_config_any, now_unix, now_unix_str, resolve_destinations, scope_root};
 use crate::lock::{load_lock, save_lock};
 use crate::model::{resolve_scope, Action, Config, Report, Scope, State, Summary};
 use crate::state::{load_runtime_state, save_runtime_state, RuntimeState};
@@ -178,7 +178,7 @@ pub(crate) fn run(opts: &SyncOptions) -> Result<()> {
 
     if !opts.dry_run {
         save_lock(&mut lock, scope, &cfg_dir)?;
-        runtime.last_run = Some(now_iso());
+        runtime.last_run = Some(now_unix_str());
         runtime.save_report_json(&serde_json::to_string(&report)?);
         save_runtime_state(&runtime, scope, &cfg_dir)?;
     }

--- a/src/commands/sync/skills.rs
+++ b/src/commands/sync/skills.rs
@@ -526,16 +526,8 @@ fn remove_stale_skills(ctx: &SyncContext, sm: &mut SyncMut<'_>, desired_keys: &H
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fsops::temp_dir;
     use crate::model::{Config, Scope, SkillTarget};
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn temp_dir(prefix: &str) -> PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        std::env::temp_dir().join(format!("kasetto-{prefix}-{}-{nonce}", std::process::id()))
-    }
 
     fn write_skill(root: &Path, name: &str, body: &str) {
         let dir = root.join(name);
@@ -600,11 +592,11 @@ mod tests {
     }
 
     fn setup(skill_names: &[&str]) -> Harness {
-        let src_root = temp_dir("src");
+        let src_root = temp_dir("kasetto-src");
         for n in skill_names {
             write_skill(&src_root, n, &format!("# {n}\n\nbody\n"));
         }
-        let scope_root = temp_dir("scope");
+        let scope_root = temp_dir("kasetto-scope");
         let dest = scope_root.join(".agent/skills");
         fs::create_dir_all(&dest).unwrap();
         Harness {

--- a/src/commands/sync/skills.rs
+++ b/src/commands/sync/skills.rs
@@ -190,15 +190,15 @@ fn record_broken_skills(
 ) {
     for broken in broken_skills {
         sm.summary.broken += 1;
-        sm.actions.push(Action {
-            source: Some(source.to_string()),
-            skill: Some(broken.name.clone()),
-            status: "broken".into(),
-            error: Some(broken.reason.clone()),
-        });
         if !ctx.as_json && !ctx.quiet {
             eprint_fail(&broken.name, source, ctx.plain);
         }
+        sm.actions.push(Action {
+            source: Some(source.to_string()),
+            skill: Some(broken.name),
+            status: "broken".into(),
+            error: Some(broken.reason),
+        });
     }
 }
 

--- a/src/commands/sync/skills.rs
+++ b/src/commands/sync/skills.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -23,8 +23,70 @@ fn skill_key(source: &str, skill: &str) -> String {
     format!("{source}::{skill}")
 }
 
+/// Per-run memo of destination-directory hashes. `needs_fetch` and the
+/// process step would otherwise re-walk and re-SHA256 the same skill dir up to
+/// three times per sync; with the memo each dir is hashed once. Entries are
+/// refreshed after a copy writes new content. `None` = missing or unreadable.
+#[derive(Default)]
+struct HashCache(HashMap<PathBuf, Option<String>>);
+
+impl HashCache {
+    fn get(&mut self, dir: &Path) -> Option<&str> {
+        self.0
+            .entry(dir.to_path_buf())
+            .or_insert_with(|| {
+                if dir.exists() {
+                    hash_dir(dir).ok()
+                } else {
+                    None
+                }
+            })
+            .as_deref()
+    }
+
+    fn set(&mut self, dir: PathBuf, hash: String) {
+        self.0.insert(dir, Some(hash));
+    }
+
+    /// Mark a destination unknown before a copy rewrites it. `copy_dir`
+    /// deletes the destination before writing, so a mid-copy failure would
+    /// otherwise leave a stale "good" hash memoized for a missing/partial dir.
+    fn invalidate(&mut self, dir: &Path) {
+        self.0.insert(dir.to_path_buf(), None);
+    }
+}
+
+/// One pass over all destinations of a skill: whether every copy matches the
+/// expected hash, and the first verified-good copy (usable as a repair source).
+struct DestStatus {
+    all_match: bool,
+    good: Option<PathBuf>,
+}
+
+fn dest_status(
+    ctx: &SyncContext,
+    cache: &mut HashCache,
+    skill_name: &str,
+    expected_hash: &str,
+) -> DestStatus {
+    let mut all_match = true;
+    let mut good = None;
+    for agent_dest in ctx.destinations {
+        let dir = agent_dest.join(skill_name);
+        if cache.get(&dir) == Some(expected_hash) {
+            if good.is_none() {
+                good = Some(dir);
+            }
+        } else {
+            all_match = false;
+        }
+    }
+    DestStatus { all_match, good }
+}
+
 pub(super) fn sync_skills(ctx: &SyncContext, sm: &mut SyncMut<'_>) -> Result<()> {
     let mut desired_keys = HashSet::new();
+    let mut cache = HashCache::default();
 
     for (i, src) in ctx.cfg.skills.iter().enumerate() {
         // Desired skill names for this source, derived without any network:
@@ -46,7 +108,7 @@ pub(super) fn sync_skills(ctx: &SyncContext, sm: &mut SyncMut<'_>) -> Result<()>
         }
 
         let update_active = update_active_for_source(ctx, &desired);
-        let fetch = update_active || needs_fetch(ctx, src, &desired, sm.state);
+        let fetch = update_active || needs_fetch(ctx, &mut cache, src, &desired, sm.state);
 
         if fetch && ctx.locked {
             // --locked must never fetch. If the lock cannot satisfy the config
@@ -65,9 +127,9 @@ pub(super) fn sync_skills(ctx: &SyncContext, sm: &mut SyncMut<'_>) -> Result<()>
         }
 
         if fetch {
-            sync_source_via_fetch(ctx, sm, &mut desired_keys, src, i);
+            sync_source_via_fetch(ctx, sm, &mut cache, &mut desired_keys, src, i);
         } else {
-            sync_source_from_lock(ctx, sm, &mut desired_keys, src, &desired);
+            sync_source_from_lock(ctx, sm, &mut cache, &mut desired_keys, src, &desired);
         }
     }
 
@@ -85,6 +147,7 @@ pub(super) fn sync_skills(ctx: &SyncContext, sm: &mut SyncMut<'_>) -> Result<()>
 fn sync_source_via_fetch(
     ctx: &SyncContext,
     sm: &mut SyncMut<'_>,
+    cache: &mut HashCache,
     desired_keys: &mut HashSet<String>,
     src: &SourceSpec,
     i: usize,
@@ -108,6 +171,7 @@ fn sync_source_via_fetch(
                         if let Err(e) = process_single_skill(
                             ctx,
                             sm,
+                            cache,
                             desired_keys,
                             &src.source,
                             &materialized.source_revision,
@@ -156,6 +220,7 @@ fn sync_source_via_fetch(
 fn sync_source_from_lock(
     ctx: &SyncContext,
     sm: &mut SyncMut<'_>,
+    cache: &mut HashCache,
     desired_keys: &mut HashSet<String>,
     src: &SourceSpec,
     desired: &[String],
@@ -170,7 +235,7 @@ fn sync_source_from_lock(
         };
         let label = sync_label_with(skill_name, &src.source, ctx.plain, first_in_run);
         first_in_run = false;
-        if let Err(e) = process_locked_skill(ctx, sm, &entry, skill_name, &label) {
+        if let Err(e) = process_locked_skill(ctx, sm, cache, &entry, skill_name, &label) {
             sm.summary.failed += 1;
             sm.actions.push(Action {
                 source: Some(src.source.clone()),
@@ -206,6 +271,7 @@ fn record_broken_skills(
 fn process_single_skill(
     ctx: &SyncContext,
     sm: &mut SyncMut<'_>,
+    cache: &mut HashCache,
     desired_keys: &mut HashSet<String>,
     source: &str,
     source_revision: &str,
@@ -227,7 +293,9 @@ fn process_single_skill(
             .state
             .skills
             .get(&key)
-            .map(|prev| prev.hash == hash && all_destinations_match(ctx, skill_name, &prev.hash))
+            .map(|prev| {
+                prev.hash == hash && dest_status(ctx, cache, skill_name, &prev.hash).all_match
+            })
             .unwrap_or(false);
 
         if is_unchanged {
@@ -264,7 +332,10 @@ fn process_single_skill(
         }
 
         for agent_dest in ctx.destinations {
-            copy_dir(skill_path, &agent_dest.join(skill_name))?;
+            let dst = agent_dest.join(skill_name);
+            cache.invalidate(&dst);
+            copy_dir(skill_path, &dst)?;
+            cache.set(dst, hash.clone());
         }
         let status = if sm.state.skills.contains_key(&key) {
             sm.summary.updated += 1;
@@ -302,17 +373,18 @@ fn process_single_skill(
 fn process_locked_skill(
     ctx: &SyncContext,
     sm: &mut SyncMut<'_>,
+    cache: &mut HashCache,
     entry: &SkillEntry,
     skill_name: &str,
     label: &str,
 ) -> Result<()> {
     let key = skill_key(&entry.source, skill_name);
     with_spinner_transient(ctx.animate, ctx.plain, label, || {
-        // A destination is good when it exists and re-hashes to the locked hash.
-        let good = good_destination(ctx, skill_name, &entry.hash);
-        let all_ok = all_destinations_match(ctx, skill_name, &entry.hash);
+        // One pass: per-destination match against the locked hash, plus the
+        // first verified-good copy as the repair source.
+        let DestStatus { all_match, good } = dest_status(ctx, cache, skill_name, &entry.hash);
 
-        if all_ok {
+        if all_match {
             sm.summary.unchanged += 1;
             sm.actions.push(Action {
                 source: Some(entry.source.clone()),
@@ -344,7 +416,9 @@ fn process_locked_skill(
         for agent_dest in ctx.destinations {
             let dst = agent_dest.join(skill_name);
             if dst != src_dir {
+                cache.invalidate(&dst);
                 copy_dir(&src_dir, &dst)?;
+                cache.set(dst, entry.hash.clone());
             }
         }
         sm.runtime.set_updated_at(&key, now_unix_str());
@@ -415,7 +489,13 @@ fn ensure_locked_satisfiable(src: &SourceSpec, desired: &[String], state: &State
 /// Per-source fetch decision (computed before any download). Fetch when any
 /// desired skill lacks a lock entry, or its locked copy is missing/mismatched on
 /// any destination with no good local copy available to repair from.
-fn needs_fetch(ctx: &SyncContext, src: &SourceSpec, desired: &[String], state: &State) -> bool {
+fn needs_fetch(
+    ctx: &SyncContext,
+    cache: &mut HashCache,
+    src: &SourceSpec,
+    desired: &[String],
+    state: &State,
+) -> bool {
     // A wildcard source with no lock entries has never been resolved — bootstrap
     // it by fetching (the locked set is empty only because nothing is pinned yet).
     if matches!(src.skills, SkillsField::Wildcard(_))
@@ -436,40 +516,15 @@ fn needs_fetch(ctx: &SyncContext, src: &SourceSpec, desired: &[String], state: &
         if !entry.source_revision.is_empty() && entry.source_revision != expected_revision {
             return true;
         }
-        // Re-hash every destination; if all match, this skill is satisfied.
-        if all_destinations_match(ctx, skill_name, &entry.hash) {
-            continue;
-        }
-        // Some destination is missing/mismatched. If at least one good local copy
-        // exists we can repair without a fetch; otherwise we must fetch.
-        if good_destination(ctx, skill_name, &entry.hash).is_none() {
+        // Hash every destination once (memoized for the process step). All
+        // matching → satisfied; some mismatched but one good copy → local
+        // repair is possible; no good copy → must fetch.
+        let status = dest_status(ctx, cache, skill_name, &entry.hash);
+        if !status.all_match && status.good.is_none() {
             return true;
         }
     }
     false
-}
-
-/// The first destination that exists and re-hashes to `expected_hash`.
-fn good_destination(ctx: &SyncContext, skill_name: &str, expected_hash: &str) -> Option<PathBuf> {
-    for agent_dest in ctx.destinations {
-        let dir = agent_dest.join(skill_name);
-        if dir.exists() {
-            if let Ok(h) = hash_dir(&dir) {
-                if h == expected_hash {
-                    return Some(dir);
-                }
-            }
-        }
-    }
-    None
-}
-
-/// True when every destination holds a copy that re-hashes to `expected_hash`.
-fn all_destinations_match(ctx: &SyncContext, skill_name: &str, expected_hash: &str) -> bool {
-    ctx.destinations.iter().all(|agent_dest| {
-        let dir = agent_dest.join(skill_name);
-        dir.exists() && hash_dir(&dir).map(|h| h == expected_hash).unwrap_or(false)
-    })
 }
 
 /// Stale-skill cleanup. Routes through the shared [`remove_stale`] helper so

--- a/src/commands/sync/skills.rs
+++ b/src/commands/sync/skills.rs
@@ -17,6 +17,12 @@ use super::{
     remove_stale, sync_label_with, update_active_for_source, StaleEntry, SyncContext, SyncMut,
 };
 
+/// Lock key for a skill: `<source>::<name>`. Single point of truth so the key
+/// format cannot drift between the lock writer and the lookup sites.
+fn skill_key(source: &str, skill: &str) -> String {
+    format!("{source}::{skill}")
+}
+
 pub(super) fn sync_skills(ctx: &SyncContext, sm: &mut SyncMut<'_>) -> Result<()> {
     let mut desired_keys = HashSet::new();
 
@@ -156,7 +162,7 @@ fn sync_source_from_lock(
 ) {
     let mut first_in_run = true;
     for skill_name in desired {
-        let key = format!("{}::{}", src.source, skill_name);
+        let key = skill_key(&src.source, skill_name);
         desired_keys.insert(key.clone());
         let Some(entry) = sm.state.skills.get(&key).cloned() else {
             // needs_fetch would have been true; defensive guard.
@@ -210,7 +216,7 @@ fn process_single_skill(
     let destination = &ctx.destinations[0];
     let (_, profile_description) = read_skill_profile_from_dir(skill_path, skill_name);
     with_spinner_transient(ctx.animate, ctx.plain, label, || {
-        let key = format!("{source}::{skill_name}");
+        let key = skill_key(source, skill_name);
         desired_keys.insert(key.clone());
         let hash = hash_dir(skill_path)?;
         let dest = destination.join(skill_name);
@@ -300,7 +306,7 @@ fn process_locked_skill(
     skill_name: &str,
     label: &str,
 ) -> Result<()> {
-    let key = format!("{}::{}", entry.source, skill_name);
+    let key = skill_key(&entry.source, skill_name);
     with_spinner_transient(ctx.animate, ctx.plain, label, || {
         // A destination is good when it exists and re-hashes to the locked hash.
         let good = good_destination(ctx, skill_name, &entry.hash);
@@ -381,7 +387,7 @@ fn ensure_locked_satisfiable(src: &SourceSpec, desired: &[String], state: &State
     match &src.skills {
         SkillsField::List(_) => {
             for name in desired {
-                let key = format!("{}::{}", src.source, name);
+                let key = skill_key(&src.source, name);
                 if !state.skills.contains_key(&key) {
                     return Err(err(format!(
                         "--locked: skill `{name}` from `{}` is not in the lock",
@@ -419,7 +425,7 @@ fn needs_fetch(ctx: &SyncContext, src: &SourceSpec, desired: &[String], state: &
     }
     let expected_revision = src.expected_revision();
     for skill_name in desired {
-        let key = format!("{}::{}", src.source, skill_name);
+        let key = skill_key(&src.source, skill_name);
         // A skill named in the config but absent from the lock must be fetched.
         let Some(entry) = state.skills.get(&key) else {
             return true;

--- a/src/commands/sync/skills.rs
+++ b/src/commands/sync/skills.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{err, Result};
 use crate::fsops::{
-    copy_dir, hash_dir, now_iso, now_unix, relativize_dest, select_targets, BrokenSkill,
+    copy_dir, hash_dir, now_unix, now_unix_str, relativize_dest, select_targets, BrokenSkill,
 };
 use crate::model::{Action, SkillEntry, SkillsField, SourceSpec, State};
 use crate::profile::read_skill_profile_from_dir;
@@ -267,7 +267,7 @@ fn process_single_skill(
             sm.summary.installed += 1;
             "installed"
         };
-        sm.runtime.set_updated_at(&key, now_iso());
+        sm.runtime.set_updated_at(&key, now_unix_str());
         sm.state.skills.insert(
             key,
             SkillEntry {
@@ -341,7 +341,7 @@ fn process_locked_skill(
                 copy_dir(&src_dir, &dst)?;
             }
         }
-        sm.runtime.set_updated_at(&key, now_iso());
+        sm.runtime.set_updated_at(&key, now_unix_str());
         // Lock entry is unchanged (hash + revision identical); nothing to rewrite.
         sm.summary.updated += 1;
         sm.actions.push(Action {

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -120,7 +120,7 @@ fn remove_dir_if_exists(path: Option<&Path>) -> Result<bool> {
     Ok(true)
 }
 
-fn remove_file_if_exists(path: &PathBuf) -> Result<bool> {
+fn remove_file_if_exists(path: &Path) -> Result<bool> {
     if path.exists() || path.symlink_metadata().is_ok() {
         fs::remove_file(path)
             .map_err(|e| err(format!("failed to remove {}: {e}", path.display())))?;

--- a/src/fsops/config.rs
+++ b/src/fsops/config.rs
@@ -90,10 +90,8 @@ fn fetch_config_text(
     parent_base_dir: Option<&Path>,
 ) -> Result<(String, ConfigOrigin)> {
     if config_ref.starts_with("http://") || config_ref.starts_with("https://") {
-        let fetch_url = match rewrite_browse_to_raw_url(config_ref) {
-            Some(rewritten) => rewritten,
-            None => config_ref.to_string(),
-        };
+        let fetch_url =
+            rewrite_browse_to_raw_url(config_ref).unwrap_or_else(|| config_ref.to_string());
         let auth = auth_for_request_url(&fetch_url);
         let request = auth.apply(http_client()?.get(&fetch_url));
         let response = request
@@ -120,7 +118,7 @@ fn fetch_config_text(
         return Ok((
             text,
             ConfigOrigin {
-                canonical_id: fetch_url.clone(),
+                canonical_id: fetch_url,
                 base_dir: None,
                 label: config_ref.to_string(),
             },

--- a/src/fsops/config_edit.rs
+++ b/src/fsops/config_edit.rs
@@ -143,7 +143,7 @@ pub(crate) fn insert_item(text: &str, section: Section, item: &SourceItem) -> Re
         }
     }
 
-    Ok(join_lines(lines, text))
+    Ok(join_lines(&lines, text))
 }
 
 /// Find the single section item matching `source` (and `pin` / `sub_dir`, when
@@ -202,7 +202,7 @@ pub(crate) fn remove_item(
         Some(it) => {
             let (start, end) = (it.start, it.end);
             lines.drain(start..end);
-            Ok((join_lines(lines, text), true))
+            Ok((join_lines(&lines, text), true))
         }
     }
 }
@@ -303,7 +303,7 @@ pub(crate) fn remove_names(
     if remaining == 0 {
         // Removing every name empties the list — drop the whole entry.
         lines.drain(istart..iend);
-        return Ok((join_lines(lines, text), RemoveOutcome::WholeItem));
+        return Ok((join_lines(&lines, text), RemoveOutcome::WholeItem));
     }
 
     let mut to_delete: Vec<usize> = name_lines
@@ -316,7 +316,7 @@ pub(crate) fn remove_names(
         lines.remove(i);
     }
     Ok((
-        join_lines(lines, text),
+        join_lines(&lines, text),
         RemoveOutcome::Names(names.to_vec()),
     ))
 }
@@ -330,12 +330,12 @@ pub(crate) fn item_exists(text: &str, section: Section, item: &SourceItem) -> bo
         return false;
     };
     let sec_end = next_top_level(&lines, idx + 1);
-    let want_pin = item.pin.value().unwrap_or("").to_string();
-    let want_sub = item.sub_dir.clone().unwrap_or_default();
+    let want_pin = item.pin.value().unwrap_or("");
+    let want_sub = item.sub_dir.as_deref().unwrap_or("");
     parse_items(&lines, idx + 1, sec_end).iter().any(|it| {
         it.source.as_deref() == Some(item.source.as_str())
-            && it.pin.clone().unwrap_or_default() == want_pin
-            && it.sub_dir.clone().unwrap_or_default() == want_sub
+            && it.pin.as_deref().unwrap_or("") == want_pin
+            && it.sub_dir.as_deref().unwrap_or("") == want_sub
     })
 }
 
@@ -370,7 +370,7 @@ fn split_lines(text: &str) -> Vec<String> {
     text.lines().map(String::from).collect()
 }
 
-fn join_lines(lines: Vec<String>, original: &str) -> String {
+fn join_lines(lines: &[String], original: &str) -> String {
     let mut out = lines.join("\n");
     if original.ends_with('\n') || original.is_empty() {
         out.push('\n');
@@ -618,7 +618,8 @@ mod tests {
     #[test]
     fn remove_disambiguates_by_pin() {
         let text = "skills:\n  - source: https://x/a\n    ref: v1\n    skills: \"*\"\n  - source: https://x/a\n    ref: v2\n    skills: \"*\"\n";
-        let (out, removed) = remove_item(text, Section::Skills, "https://x/a", Some("v1"), None).unwrap();
+        let (out, removed) =
+            remove_item(text, Section::Skills, "https://x/a", Some("v1"), None).unwrap();
         assert!(removed);
         assert!(out.contains("ref: v2"));
         assert!(!out.contains("ref: v1"));
@@ -664,7 +665,7 @@ mod tests {
 
         let diff_ref = SourceItem {
             pin: Pin::Ref("v2".into()),
-            ..same.clone()
+            ..same
         };
         assert!(!item_exists(text, Section::Skills, &diff_ref));
     }
@@ -785,8 +786,15 @@ mod tests {
         // The same invariant for the names path: stripping the last name drops
         // the entry, leaving only the section header.
         let text = "mcps:\n  - source: https://x/a\n    mcps:\n      - foo\n";
-        let (out, outcome) =
-            remove_names(text, Section::Mcps, "https://x/a", None, None, &["foo".into()]).unwrap();
+        let (out, outcome) = remove_names(
+            text,
+            Section::Mcps,
+            "https://x/a",
+            None,
+            None,
+            &["foo".into()],
+        )
+        .unwrap();
         assert_eq!(outcome, RemoveOutcome::WholeItem);
         assert_eq!(out, "mcps:\n");
     }

--- a/src/fsops/copy.rs
+++ b/src/fsops/copy.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::io::{BufReader, BufWriter, Write};
 use std::path::Path;
 
 use crate::error::{err, Result};
@@ -49,10 +48,20 @@ fn copy_file(src: &Path, dst: &Path) -> Result<()> {
     if let Some(parent) = dst.parent() {
         fs::create_dir_all(parent)?;
     }
-    let mut reader = BufReader::new(fs::File::open(src)?);
-    let mut writer = BufWriter::new(fs::File::create(dst)?);
-    std::io::copy(&mut reader, &mut writer)?;
-    writer.flush()?;
+    // fs::copy uses kernel-level copy where available and preserves
+    // permissions, so executable scripts inside skills keep their +x bit.
+    fs::copy(src, dst)?;
+    // A propagated READONLY attribute would wedge every later re-sync on
+    // Windows: remove_dir_all fails with PermissionDenied on read-only files.
+    // Unix is unaffected (unlink is governed by the parent dir).
+    #[cfg(windows)]
+    {
+        let mut perms = fs::metadata(dst)?.permissions();
+        if perms.readonly() {
+            perms.set_readonly(false);
+            fs::set_permissions(dst, perms)?;
+        }
+    }
     Ok(())
 }
 
@@ -60,6 +69,30 @@ fn copy_file(src: &Path, dst: &Path) -> Result<()> {
 mod tests {
     use super::*;
     use crate::fsops::temp_dir;
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_dir_preserves_executable_bit() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let src = temp_dir("kasetto-copy-perm-src");
+        fs::create_dir_all(&src).expect("create src");
+        let script = src.join("run.sh");
+        fs::write(&script, "#!/bin/sh\n").expect("write script");
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        let dst = temp_dir("kasetto-copy-perm-dst");
+        copy_dir(&src, &dst).expect("copy dir");
+
+        let mode = fs::metadata(dst.join("run.sh"))
+            .expect("metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o111, 0o111, "executable bit must survive the copy");
+
+        let _ = fs::remove_dir_all(&src);
+        let _ = fs::remove_dir_all(&dst);
+    }
 
     #[cfg(unix)]
     #[test]

--- a/src/fsops/copy.rs
+++ b/src/fsops/copy.rs
@@ -59,15 +59,7 @@ fn copy_file(src: &Path, dst: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn temp_dir(prefix: &str) -> std::path::PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        std::env::temp_dir().join(format!("{prefix}-{}-{nonce}", std::process::id()))
-    }
+    use crate::fsops::temp_dir;
 
     #[cfg(unix)]
     #[test]

--- a/src/fsops/hash.rs
+++ b/src/fsops/hash.rs
@@ -76,15 +76,7 @@ fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn temp_dir(prefix: &str) -> PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        std::env::temp_dir().join(format!("{prefix}-{}-{nonce}", std::process::id()))
-    }
+    use crate::fsops::temp_dir;
 
     /// The relative-path bytes fed into the digest must be separator-invariant:
     /// `a\b` and `a/b` must contribute identically so the same skill hashes the

--- a/src/fsops/mod.rs
+++ b/src/fsops/mod.rs
@@ -254,8 +254,8 @@ pub(crate) fn now_unix() -> u64 {
         .unwrap_or(0)
 }
 
-pub(crate) fn now_iso() -> String {
-    format!("{}", now_unix())
+pub(crate) fn now_unix_str() -> String {
+    now_unix().to_string()
 }
 
 /// Unique scratch directory for tests. Parallel test threads can observe the

--- a/src/fsops/mod.rs
+++ b/src/fsops/mod.rs
@@ -255,13 +255,18 @@ pub(crate) fn now_iso() -> String {
     format!("{}", now_unix())
 }
 
+/// Unique scratch directory for tests. Parallel test threads can observe the
+/// same nanosecond, so a process-wide counter keeps concurrently created dirs
+/// distinct; the nanos guard against stale dirs from a crashed earlier run.
 #[cfg(test)]
 pub(crate) fn temp_dir(prefix: &str) -> PathBuf {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let nonce = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("clock")
         .as_nanos();
-    std::env::temp_dir().join(format!("{prefix}-{}-{nonce}", std::process::id()))
+    std::env::temp_dir().join(format!("{prefix}-{}-{seq}-{nonce}", std::process::id()))
 }
 
 #[cfg(test)]

--- a/src/fsops/mod.rs
+++ b/src/fsops/mod.rs
@@ -98,17 +98,17 @@ pub(crate) struct BrokenSkill {
 }
 
 pub(crate) fn resolve_path(base: &Path, raw: &str) -> PathBuf {
-    let p = if raw.contains('~') {
-        PathBuf::from(
-            raw.replace(
-                '~',
-                &dirs_home()
-                    .unwrap_or_else(|_| PathBuf::from("~"))
-                    .to_string_lossy(),
-            ),
-        )
-    } else {
-        PathBuf::from(raw)
+    // Expand only a leading `~` (home prefix); a `~` elsewhere in the path is
+    // an ordinary character (e.g. `./backup~old`) and must not be rewritten.
+    let p = match raw
+        .strip_prefix("~/")
+        .or(if raw == "~" { Some("") } else { None })
+    {
+        Some(rest) => match dirs_home() {
+            Ok(home) => home.join(rest),
+            Err(_) => PathBuf::from(raw),
+        },
+        None => PathBuf::from(raw),
     };
     if p.is_absolute() {
         p
@@ -277,6 +277,19 @@ mod tests {
     };
     use std::fs;
     use std::path::Path;
+
+    #[test]
+    fn resolve_path_expands_only_leading_tilde() {
+        let base = Path::new("/base");
+        let home = dirs_home().expect("home");
+        assert_eq!(resolve_path(base, "~/skills"), home.join("skills"));
+        assert_eq!(resolve_path(base, "~"), home);
+        // A `~` that is not the home prefix is an ordinary path character.
+        assert_eq!(
+            resolve_path(base, "backup~old/skills"),
+            Path::new("/base/backup~old/skills")
+        );
+    }
 
     #[test]
     fn select_targets_reports_missing_skill() {

--- a/src/fsops/mod.rs
+++ b/src/fsops/mod.rs
@@ -38,6 +38,9 @@ pub(crate) fn select_targets(
             for (k, v) in available {
                 out.push((k.clone(), v.clone()));
             }
+            // HashMap iteration order is random; sort so install order, labels,
+            // and --json output are stable across runs.
+            out.sort_by(|a, b| a.0.cmp(&b.0));
         }
         SkillsField::List(items) => {
             for it in items {
@@ -289,6 +292,19 @@ mod tests {
             resolve_path(base, "backup~old/skills"),
             Path::new("/base/backup~old/skills")
         );
+    }
+
+    #[test]
+    fn select_targets_wildcard_is_sorted() {
+        let mut available = HashMap::new();
+        for name in ["zeta", "alpha", "mid"] {
+            available.insert(name.to_string(), PathBuf::from(format!("/tmp/{name}")));
+        }
+        let sf = SkillsField::Wildcard("*".into());
+
+        let (targets, _) = select_targets(&sf, &available, Path::new("/tmp")).expect("select");
+        let names: Vec<&str> = targets.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "mid", "zeta"]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,16 +74,8 @@ fn resolve_config_path(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fsops::temp_dir;
     use std::fs;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn temp_dir(prefix: &str) -> std::path::PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        std::env::temp_dir().join(format!("{prefix}-{}-{nonce}", std::process::id()))
-    }
 
     #[test]
     fn env_var_takes_highest_priority() {

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -110,7 +110,7 @@ impl LockFile {
     pub(crate) fn list_installed_mcps(&self) -> Vec<String> {
         let mut servers: Vec<String> = self
             .list_tracked_asset_ids("mcp")
-            .iter()
+            .into_iter()
             .flat_map(|(_, dest_csv)| {
                 dest_csv
                     .split(',')

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -165,15 +165,7 @@ pub(crate) fn save_lock(lock: &mut LockFile, scope: Scope, project_root: &Path) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn temp_dir(prefix: &str) -> PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        std::env::temp_dir().join(format!("{prefix}-{}-{nonce}", std::process::id()))
-    }
+    use crate::fsops::temp_dir;
 
     #[test]
     fn round_trip_empty_lock_file() {

--- a/src/mcps/codex.rs
+++ b/src/mcps/codex.rs
@@ -145,7 +145,8 @@ fn json_mcp_server_to_codex_toml_table(
         for (k, v) in env {
             let s = match v {
                 serde_json::Value::String(s) => s.clone(),
-                _ => v.to_string().trim_matches('"').to_string(),
+                // Non-string values (numbers, bools) are rendered via Display.
+                _ => v.to_string(),
             };
             et.insert(k.clone(), Toml::String(s));
         }

--- a/src/mcps/merge.rs
+++ b/src/mcps/merge.rs
@@ -36,14 +36,8 @@ fn merge_into_json_key(
     Ok(())
 }
 
-fn identity(v: serde_json::Value) -> Result<serde_json::Value> {
-    Ok(v)
-}
-
 pub(super) fn merge_mcp_servers_object(source_path: &Path, target_path: &Path) -> Result<()> {
-    merge_into_json_key(source_path, target_path, "mcpServers", |_name, v| {
-        identity(v)
-    })
+    merge_into_json_key(source_path, target_path, "mcpServers", |_name, v| Ok(v))
 }
 
 pub(super) fn merge_vscode_servers_object(source_path: &Path, target_path: &Path) -> Result<()> {

--- a/src/mcps/mod.rs
+++ b/src/mcps/mod.rs
@@ -90,17 +90,10 @@ fn json_all_keys_present(server_names: &[String], path: &Path, root_key: &str) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fsops::temp_dir;
     use crate::model::McpSettingsTarget;
     use std::fs;
     use toml::Value as TomlVal;
-
-    fn temp_dir(prefix: &str) -> std::path::PathBuf {
-        let nonce = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        std::env::temp_dir().join(format!("{prefix}-{}-{nonce}", std::process::id()))
-    }
 
     fn mcp_target(path: std::path::PathBuf) -> McpSettingsTarget {
         McpSettingsTarget {

--- a/src/mcps/mod.rs
+++ b/src/mcps/mod.rs
@@ -359,7 +359,7 @@ command = "b"
 
         assert!(servers_present_in_settings(
             &["airflow".into(), "git".into()],
-            &mcp_target(settings.clone())
+            &mcp_target(settings)
         ));
         let _ = fs::remove_dir_all(&dir);
     }
@@ -373,7 +373,7 @@ command = "b"
 
         assert!(!servers_present_in_settings(
             &["airflow".into(), "git".into()],
-            &mcp_target(settings.clone())
+            &mcp_target(settings)
         ));
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src/model/extend.rs
+++ b/src/model/extend.rs
@@ -12,7 +12,7 @@ pub(crate) fn extract_extends(v: &mut Value) -> Vec<String> {
     let Value::Mapping(map) = v else {
         return Vec::new();
     };
-    let Some(raw) = map.remove(Value::String("extends".into())) else {
+    let Some(raw) = map.remove("extends") else {
         return Vec::new();
     };
     match raw {
@@ -31,24 +31,24 @@ pub(crate) fn extract_extends(v: &mut Value) -> Vec<String> {
 /// Merge `overlay` on top of `base`. Both should be top-level config mappings.
 /// Returns `overlay` unchanged if either side is not a mapping.
 pub(crate) fn merge_yaml(base: Value, overlay: Value) -> Value {
-    let (Value::Mapping(base_map), Value::Mapping(overlay_map)) = (&base, &overlay) else {
+    let Value::Mapping(mut out) = base else {
         return overlay;
     };
-    let mut out = base_map.clone();
-    for (key, ov_val) in overlay_map.clone() {
+    let overlay_map = match overlay {
+        Value::Mapping(m) => m,
+        other => return other,
+    };
+    for (key, ov_val) in overlay_map {
         let key_str = key.as_str().unwrap_or("");
-        if matches!(key_str, "skills" | "mcps" | "commands") {
-            if let Some(base_val) = out.get(&key) {
-                if let (Value::Sequence(base_seq), Value::Sequence(ov_seq)) =
-                    (base_val.clone(), ov_val.clone())
-                {
-                    let merged = merge_source_list(base_seq, ov_seq);
-                    out.insert(key, Value::Sequence(merged));
-                    continue;
-                }
+        let is_source_list = matches!(key_str, "skills" | "mcps" | "commands");
+        match (is_source_list.then(|| out.remove(&key)).flatten(), ov_val) {
+            (Some(Value::Sequence(base_seq)), Value::Sequence(ov_seq)) => {
+                out.insert(key, Value::Sequence(merge_source_list(base_seq, ov_seq)));
+            }
+            (_, ov) => {
+                out.insert(key, ov);
             }
         }
-        out.insert(key, ov_val);
     }
     Value::Mapping(out)
 }
@@ -84,9 +84,7 @@ fn identity_of(entry: &Value) -> (String, String, String) {
 }
 
 fn string_field(m: &Mapping, key: &str) -> Option<String> {
-    m.get(Value::String(key.into()))
-        .and_then(Value::as_str)
-        .map(str::to_string)
+    m.get(key).and_then(Value::as_str).map(str::to_string)
 }
 
 #[cfg(test)]

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -117,16 +117,7 @@ pub(crate) fn list_color_enabled() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn temp_dir(prefix: &str) -> PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        std::env::temp_dir().join(format!("{prefix}-{}-{nonce}", std::process::id()))
-    }
+    use crate::fsops::temp_dir;
 
     #[test]
     fn profile_prefers_heading_and_frontmatter_description() {

--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -34,16 +34,8 @@ pub(crate) fn apply_command(source: &Path, target: &CommandTarget, name: &str) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fsops::temp_dir;
     use crate::model::CommandFormat;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn temp_dir(prefix: &str) -> PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        std::env::temp_dir().join(format!("{prefix}-{}-{nonce}", std::process::id()))
-    }
 
     #[test]
     fn apply_command_writes_nested_markdown() {

--- a/src/prompts/transform.rs
+++ b/src/prompts/transform.rs
@@ -21,10 +21,9 @@ fn derive_relpath(name: &str, format: CommandFormat) -> PathBuf {
 
 fn name_to_nested_path(name: &str, ext: &str) -> PathBuf {
     let mut parts: Vec<&str> = name.split(':').filter(|p| !p.is_empty()).collect();
-    if parts.is_empty() {
+    let Some(last) = parts.pop() else {
         return PathBuf::from(format!("command.{ext}"));
-    }
-    let last = parts.pop().unwrap();
+    };
     let mut path = PathBuf::new();
     for p in parts {
         path.push(p);

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -358,16 +358,8 @@ fn resolve_named_command(root: &Path, name: &str) -> Result<(String, PathBuf)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fsops::temp_dir;
     use crate::model::{SkillsField, SourceSpec};
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn temp_dir(prefix: &str) -> PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        std::env::temp_dir().join(format!("{prefix}-{}-{nonce}", std::process::id()))
-    }
 
     #[test]
     fn local_materialize_does_not_set_cleanup_dir() {

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -160,7 +160,7 @@ fn discover_with_root_name(
     discover_skills_in_subdir(root, &mut out)?;
     discover_skills_in_subdir(&root.join("skills"), &mut out)?;
     if let Some(ref name) = root_skill_name {
-        if out.get(name).map(|p| p != root) == Some(true) {
+        if out.get(name).is_some_and(|p| p != root) {
             eprintln!("warning: subdirectory skill `{name}` shadows root-level SKILL.md");
         }
     }
@@ -178,7 +178,7 @@ fn discover_skills_in_subdir(base: &Path, out: &mut HashMap<String, PathBuf>) ->
         }
         let d = e.path();
         if d.join("SKILL.md").is_file() {
-            out.insert(e.file_name().to_string_lossy().to_string(), d);
+            out.insert(e.file_name().to_string_lossy().into_owned(), d);
         }
     }
     Ok(())
@@ -209,9 +209,7 @@ pub(crate) fn discover_mcps(root: &Path) -> Result<Vec<PathBuf>> {
         for e in fs::read_dir(mcp_dir)? {
             let e = e?;
             let path = e.path();
-            if e.file_type()?.is_file()
-                && path.extension().map(|ext| ext == "json").unwrap_or(false)
-            {
+            if e.file_type()?.is_file() && path.extension().is_some_and(|ext| ext == "json") {
                 out.push(path);
             }
         }
@@ -292,17 +290,14 @@ fn walk_commands(base: &Path, cur: &Path, out: &mut HashMap<String, PathBuf>) ->
                 _ => None,
             })
             .collect();
-        if let Some(last) = parts.last_mut() {
-            if let Some(stem) = Path::new(last)
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .map(str::to_string)
-            {
-                *last = stem;
-            }
-        }
-        if parts.is_empty() {
+        let Some(last) = parts.last_mut() else {
             continue;
+        };
+        if let Some(stem) = Path::new(last.as_str())
+            .file_stem()
+            .and_then(|s| s.to_str())
+        {
+            *last = stem.to_string();
         }
         let name = parts.join(":");
         out.insert(name, path);

--- a/src/update_notifier.rs
+++ b/src/update_notifier.rs
@@ -201,15 +201,7 @@ fn upgrade_command() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn temp_dir(prefix: &str) -> PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        std::env::temp_dir().join(format!("{prefix}-{}-{nonce}", std::process::id()))
-    }
+    use crate::fsops::temp_dir;
 
     #[test]
     fn cache_round_trip() {

--- a/src/update_notifier.rs
+++ b/src/update_notifier.rs
@@ -170,11 +170,9 @@ enum InstallMethod {
 
 fn detect_install_method() -> InstallMethod {
     let exe = std::env::current_exe().ok();
-    let path = exe
-        .as_ref()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_default();
-    classify_install_path(&path)
+    let lossy = exe.as_ref().map(|p| p.to_string_lossy());
+    let path = lossy.as_deref().unwrap_or("");
+    classify_install_path(path)
 }
 
 fn classify_install_path(path: &str) -> InstallMethod {

--- a/src/update_notifier.rs
+++ b/src/update_notifier.rs
@@ -61,7 +61,8 @@ fn write_cache(path: &std::path::Path, entry: &CacheEntry) -> std::io::Result<()
         fs::create_dir_all(parent)?;
     }
     let tmp = path.with_extension("json.tmp");
-    let text = serde_json::to_string(entry).unwrap_or_default();
+    let text = serde_json::to_string(entry)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     fs::write(&tmp, text)?;
     fs::rename(&tmp, path)?;
     Ok(())


### PR DESCRIPTION
# Pull Request Checklist

## Summary

- A per-run `HashCache` in skill sync memoizes destination-directory hashes, so each skill destination is SHA256-walked once per sync instead of up to three times (`needs_fetch`, repair-source lookup, and the process step now share one `dest_status` pass) — the dominant cost on no-fetch syncs across many agent destinations. Entries are invalidated before each `copy_dir` and refreshed after a successful copy, which also closes the TOCTOU between the fetch decision and the repair lookup.
- `copy_file` now uses `fs::copy` (kernel-level copy, clonefile on APFS) instead of a userspace buffer loop. This fixes a real bug: executable scripts inside skills lost their `+x` bit on install. On Windows the READONLY attribute is cleared post-copy so a read-only file can never wedge the next sync's `remove_dir_all`. Behavioral note: read-only source files now install read-only on Unix, matching `cp`/cargo/uv semantics.
- Correctness fixes, each with a regression test: `resolve_path` expands only a *leading* `~` (no more mangling of paths like `backup~old`); wildcard skill selection is sorted so install order and `--json` output are deterministic; `update_notifier` cache writes propagate serialization errors instead of silently writing an empty file.
- Test-suite flake fix: the per-module `temp_dir` helpers derived nonces from pid+nanos, so parallel test threads could collide (~2 in 5 full runs failed on `main`); they are consolidated into one shared helper with a process-wide atomic counter. Plus a clippy-driven clone/allocation sweep (`redundant_clone`, `needless_pass_by_value`, `needless_collect`) and small naming cleanups (`skill_key` helper, `now_iso` → `now_unix_str`).

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors