### PR TITLE
fix(site): derive agents-grid preset count from list length

### DIFF
--- a/site/app/components/agents-grid.tsx
+++ b/site/app/components/agents-grid.tsx
@@ -37,7 +37,7 @@ export function AgentsGrid() {
   return (
     <div className="grid-box">
       <div className="agents-header">
-        <span>21 PRESETS, BUILT IN</span>
+        <span>{AGENTS.length} PRESETS, BUILT IN</span>
       </div>
       <div className="agents-cells">
         {visible.map((agent) => (


### PR DESCRIPTION
## Summary

- The landing-page agents grid header hardcoded `21 PRESETS, BUILT IN`, which went stale when the `zcode` preset (#45, v3.6.0) grew the list to 22.
- Render `{AGENTS.length}` instead of a literal so the count can never drift from the grid again.

## Testing

- `just lint-next` and `just build-next` pass.
- Repo-wide sweep confirms no other stale "21 agents/presets" references remain.