### PR TITLE
fix(site): use canonical www host in metadata and llms.txt

### DIFF
--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -14,7 +14,7 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://kasetto.dev"),
+  metadataBase: new URL("https://www.kasetto.dev"),
   title: {
     template: "%s - Kasetto",
     default: "Kasetto",
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
   description: "Declarative AI Agent Environment Manager written in Rust",
   openGraph: {
     type: "website",
-    url: "https://kasetto.dev",
+    url: "https://www.kasetto.dev",
     siteName: "Kasetto",
     title: "Kasetto",
     description: "Declarative AI Agent Environment Manager written in Rust",

--- a/site/app/llms.txt/route.ts
+++ b/site/app/llms.txt/route.ts
@@ -2,7 +2,8 @@ import { getOrderedDocsPages } from "@/lib/markdown";
 
 export const revalidate = false;
 
-const SITE_URL = "https://kasetto.dev";
+// apex 307-redirects to www, so link the canonical host directly
+const SITE_URL = "https://www.kasetto.dev";
 
 export function GET() {
   const links = getOrderedDocsPages()


### PR DESCRIPTION
# Pull Request Checklist

## Summary

- The apex domain 307-redirects to `www`, so every link published in `llms.txt` cost agents an extra hop — and returned nothing at all to a fetcher that does not follow redirects. Point the link base at `www` so the published URLs resolve directly.
- Align `metadataBase` and the OpenGraph `url` with the same host, so canonical and social URLs stop advertising the redirecting apex.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors