### PR TITLE
feat(site): make the site crawlable and fix the canonical host

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 homepage = "https://kasetto.dev"
 repository = "https://github.com/pivoshenko/kasetto"
-documentation = "https://docs.kasetto.dev"
+documentation = "https://kasetto.dev/docs"
 keywords = [
   "claude-code",
   "codex",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://www.kasetto.dev/"><img alt="Kasetto logo" src="assets/logo.svg" width="450" /></a>
+  <a href="https://kasetto.dev/"><img alt="Kasetto logo" src="assets/logo.svg" width="450" /></a>
 </p>
 
 <p align="center">
@@ -26,7 +26,7 @@ Name comes from the Japanese word **カセット** (*kasetto*) - cassette. Think
 
 ## Why Kasetto
 
-There are good tools in this space already. [Vercel Skills](https://github.com/vercel-labs/skills) installs skills from a curated catalog, and [Claude Plugins](https://claude.com/plugins) offer runtime integrations. Both work well for one-off installs, but neither gives you a declarative, version-controlled config.
+There are good tools in this space already. [Vercel Skills](https://github.com/vercel-labs/skills) installs skills from a curated catalog, and [Claude Plugins](https://claude.com/plugins) offer runtime integrations. Both work well for one-off installs, but neither gives you a declarative, version-controlled config. See [Kasetto vs the alternatives](https://kasetto.dev/docs/vs-alternatives) for the full comparison.
 
 Kasetto is a **community-first** project that solves a different problem: **declarative, reproducible AI environment management across projects, machines, and agents.**
 

--- a/site/app/components/json-ld.tsx
+++ b/site/app/components/json-ld.tsx
@@ -1,0 +1,14 @@
+/**
+ * Emits a schema.org JSON-LD block.
+ *
+ * `<` is escaped so a string in the payload can never close the script tag.
+ */
+export function JsonLd({ data }: { data: object }) {
+  return (
+    <script
+      type="application/ld+json"
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD has to be raw script content
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data).replace(/</g, "\\u003c") }}
+    />
+  );
+}

--- a/site/app/docs/[[...slug]]/page.tsx
+++ b/site/app/docs/[[...slug]]/page.tsx
@@ -8,6 +8,14 @@ import { source } from "@/lib/source";
 import { breadcrumbJsonLd, faqJsonLd } from "@/lib/structured-data";
 import { getMDXComponents } from "@/mdx-components";
 
+/** The site-wide card image; dimensions and alt mirror `app/opengraph-image.tsx`. */
+const OG_IMAGE = {
+  url: "/opengraph-image",
+  width: 1200,
+  height: 630,
+  alt: "Kasetto: Declarative AI agent environment manager",
+};
+
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
   const params = await props.params;
   const page = source.getPage(params.slug);
@@ -46,6 +54,10 @@ export async function generateMetadata(props: {
   const page = source.getPage(params.slug);
   if (!page) notFound();
 
+  // Declaring `openGraph` here replaces the root object wholesale, so the
+  // shared card image has to be named again or docs links share with no image.
+  const title = `${page.data.title} - Kasetto`;
+
   return {
     title: page.data.title,
     description: page.data.description,
@@ -55,8 +67,17 @@ export async function generateMetadata(props: {
     openGraph: {
       type: "article",
       url: page.url,
-      title: `${page.data.title} - Kasetto`,
+      siteName: "Kasetto",
+      locale: "en_US",
+      title,
       description: page.data.description,
+      images: OG_IMAGE,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: page.data.description,
+      images: OG_IMAGE,
     },
   };
 }

--- a/site/app/docs/[[...slug]]/page.tsx
+++ b/site/app/docs/[[...slug]]/page.tsx
@@ -2,8 +2,10 @@ import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/page
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { CopyButton } from "@/app/components/copy-button";
+import { JsonLd } from "@/app/components/json-ld";
 import { getPageMarkdown } from "@/lib/markdown";
 import { source } from "@/lib/source";
+import { breadcrumbJsonLd, faqJsonLd } from "@/lib/structured-data";
 import { getMDXComponents } from "@/mdx-components";
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
@@ -12,9 +14,12 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
   if (!page) notFound();
 
   const MDX = page.data.body;
+  const faq = page.url === "/docs/faq" ? faqJsonLd(page) : null;
 
   return (
     <DocsPage toc={page.data.toc} full={page.data.full}>
+      <JsonLd data={breadcrumbJsonLd(page)} />
+      {faq && <JsonLd data={faq} />}
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <div className="docs-page-actions">
@@ -44,5 +49,14 @@ export async function generateMetadata(props: {
   return {
     title: page.data.title,
     description: page.data.description,
+    alternates: {
+      canonical: page.url,
+    },
+    openGraph: {
+      type: "article",
+      url: page.url,
+      title: `${page.data.title} - Kasetto`,
+      description: page.data.description,
+    },
   };
 }

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -3,6 +3,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import { RootProvider } from "fumadocs-ui/provider";
 import type { Metadata } from "next";
 import { JetBrains_Mono } from "next/font/google";
+import { SITE_URL } from "@/lib/site";
 import { TopNav } from "./components/top-nav";
 import "./globals.css";
 
@@ -13,25 +14,31 @@ const jetbrainsMono = JetBrains_Mono({
   variable: "--font-jetbrains-mono",
 });
 
+const DESCRIPTION =
+  "Sync skills, MCP servers, slash-commands, and instructions from Git into Claude Code, Cursor, Codex, Copilot, and 18 more agents. One YAML file, lock-pinned, in Rust.";
+
 export const metadata: Metadata = {
-  metadataBase: new URL("https://www.kasetto.dev"),
+  metadataBase: new URL(SITE_URL),
   title: {
     template: "%s - Kasetto",
-    default: "Kasetto",
+    default: "Kasetto - Declarative AI Agent Environment Manager",
   },
-  description: "Declarative AI Agent Environment Manager written in Rust",
+  description: DESCRIPTION,
+  alternates: {
+    canonical: "/",
+  },
   openGraph: {
     type: "website",
-    url: "https://www.kasetto.dev",
+    url: SITE_URL,
     siteName: "Kasetto",
-    title: "Kasetto",
-    description: "Declarative AI Agent Environment Manager written in Rust",
+    title: "Kasetto - Declarative AI Agent Environment Manager",
+    description: DESCRIPTION,
     locale: "en_US",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Kasetto",
-    description: "Declarative AI Agent Environment Manager written in Rust",
+    title: "Kasetto - Declarative AI Agent Environment Manager",
+    description: DESCRIPTION,
   },
 };
 

--- a/site/app/llms.txt/route.ts
+++ b/site/app/llms.txt/route.ts
@@ -1,9 +1,7 @@
 import { getOrderedDocsPages } from "@/lib/markdown";
+import { SITE_URL } from "@/lib/site";
 
 export const revalidate = false;
-
-// apex 307-redirects to www, so link the canonical host directly
-const SITE_URL = "https://www.kasetto.dev";
 
 export function GET() {
   const links = getOrderedDocsPages()

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -1,7 +1,9 @@
 import { FaGithub, FaGlobe, FaLinkedinIn } from "react-icons/fa";
 import { GoStar } from "react-icons/go";
+import { softwareApplicationJsonLd } from "@/lib/structured-data";
 import { AgentsGrid } from "./components/agents-grid";
 import { CopyButton } from "./components/copy-button";
+import { JsonLd } from "./components/json-ld";
 import { ConfigExample, FeatureList } from "./components/feature-tabs";
 import { SecretSources } from "./components/secret-sources";
 import { HeroTerminal } from "./components/hero-terminal";
@@ -85,6 +87,7 @@ export default async function Page() {
 
   return (
     <div className="page-wrap">
+      <JsonLd data={softwareApplicationJsonLd()} />
       {/* ── Cassette label ── */}
       <div className="logo-wrap">
         {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/site/app/robots.ts
+++ b/site/app/robots.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+
+export const revalidate = false;
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        // Raw-Markdown mirrors of the docs; noindex-ed at the header level too.
+        disallow: ["/docs-md/", "/api/"],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/site/app/sitemap.ts
+++ b/site/app/sitemap.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+import { getOrderedDocsPages } from "@/lib/markdown";
+import { SITE_URL } from "@/lib/site";
+
+export const revalidate = false;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const docs = getOrderedDocsPages().map((page) => ({
+    url: `${SITE_URL}${page.url}`,
+    changeFrequency: "weekly" as const,
+    // The docs index outranks the individual pages it links to.
+    priority: page.url === "/docs" ? 0.9 : 0.7,
+  }));
+
+  return [{ url: SITE_URL, changeFrequency: "weekly" as const, priority: 1 }, ...docs];
+}

--- a/site/content/docs/agents.mdx
+++ b/site/content/docs/agents.mdx
@@ -1,6 +1,6 @@
 ---
-title: Supported Agents
-description: The 22 agent presets Kasetto can sync to.
+title: "Supported Agents"
+description: "All 22 agents Kasetto syncs to - Claude Code, Cursor, Codex, Copilot, Windsurf, Gemini CLI and more - and where each expects its files."
 ---
 
 Set the `agent` field in your [config](/docs/configuration) and Kasetto figures out where to put things. Each preset maps to the directory that agent expects.

--- a/site/content/docs/authentication.mdx
+++ b/site/content/docs/authentication.mdx
@@ -1,6 +1,6 @@
 ---
-title: Authentication
-description: Auth tokens for private GitHub, GitLab, Bitbucket, Codeberg, and Gitea.
+title: "Private Repository Authentication"
+description: "Sync skills and commands from private GitHub, GitLab, Bitbucket, Codeberg, and Gitea repositories using environment tokens."
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/site/content/docs/ci.mdx
+++ b/site/content/docs/ci.mdx
@@ -1,6 +1,6 @@
 ---
 title: "CI & Automation"
-description: Run Kasetto in CI pipelines.
+description: "Validate kasetto.yaml in CI, catch config drift with --frozen, and keep team AI environments reproducible."
 ---
 
 **When you need this:** You want to validate `kasetto.yaml` in CI, keep team environments reproducible, or integrate Kasetto into scripts.

--- a/site/content/docs/commands.mdx
+++ b/site/content/docs/commands.mdx
@@ -1,6 +1,6 @@
 ---
-title: Commands
-description: Reference for kst add, remove, lock, sync, list, doctor, init, clean, and self-update.
+title: "CLI Command Reference"
+description: "Every Kasetto command: kst add, remove, lock, sync, list, doctor, init, clean, and self-update, with their flags and exit codes."
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -1,6 +1,6 @@
 ---
-title: Configuration
-description: Configure your kasetto.yaml (sources, agents, scope, and extends).
+title: "Configuring kasetto.yaml"
+description: "Declare skills, commands, MCP servers, and instructions in one kasetto.yaml - sources, agents, scope, and composing configs with extends."
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/site/content/docs/cookbook.mdx
+++ b/site/content/docs/cookbook.mdx
@@ -1,6 +1,6 @@
 ---
-title: Cookbook
-description: Recipes for common workflows.
+title: "Cookbook"
+description: "Copy-paste Kasetto setups for teams, monorepos, multiple agents, and pinned rollouts."
 ---
 
 **When you need this:** You want copy-paste setups for common real workflows (teams, monorepos, multiple agents, pinned rollouts).

--- a/site/content/docs/faq.mdx
+++ b/site/content/docs/faq.mdx
@@ -1,6 +1,6 @@
 ---
-title: FAQ
-description: Frequently asked questions.
+title: "FAQ"
+description: "Common questions about syncing skills, MCP servers, and instructions across AI coding agents."
 ---
 
 **When you need this:** You have a quick "what happens if..." question about syncing skills or MCPs.

--- a/site/content/docs/how-sync-works.mdx
+++ b/site/content/docs/how-sync-works.mdx
@@ -1,6 +1,6 @@
 ---
-title: How Sync Works
-description: Internals of the sync process.
+title: "How Sync Works"
+description: "How kst sync resolves sources, hashes content, diffs against kasetto.lock, and writes only what actually changed."
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Introduction
-description: Get started with Kasetto.
+title: "What is Kasetto?"
+description: "Kasetto keeps AI agent skills, MCP servers, slash-commands, and instructions in one version-controlled YAML file and syncs them to 22 agents."
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/site/content/docs/installation.mdx
+++ b/site/content/docs/installation.mdx
@@ -1,6 +1,6 @@
 ---
-title: Installing Kasetto
-description: Install Kasetto on macOS, Linux, and Windows.
+title: "Installing Kasetto"
+description: "Install the Kasetto CLI on macOS, Linux, or Windows via the standalone installer, Homebrew, Scoop, or cargo."
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/site/content/docs/meta.json
+++ b/site/content/docs/meta.json
@@ -2,6 +2,7 @@
   "title": "Documentation",
   "pages": [
     "index",
+    "vs-alternatives",
     "installation",
     "configuration",
     "commands",
@@ -10,6 +11,7 @@
     "secrets",
     "writing-skills",
     "slash-commands",
+    "sharing-instructions",
     "how-sync-works",
     "sync-flow",
     "cookbook",

--- a/site/content/docs/secrets.mdx
+++ b/site/content/docs/secrets.mdx
@@ -1,6 +1,6 @@
 ---
-title: Secret Injection
-description: Inject tokens into MCP configs at sync time with ${kst_...} placeholders. Never committed, never in the lock.
+title: "Secret Injection"
+description: "Keep API keys out of Git. Inject tokens into MCP server configs at sync time from your environment, 1Password, Vault, AWS, GCP, Azure, or Keychain."
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/site/content/docs/security.mdx
+++ b/site/content/docs/security.mdx
@@ -1,6 +1,6 @@
 ---
-title: Security Model
-description: Security model and threat boundaries.
+title: "Security Model"
+description: "What Kasetto can write to disk, how it handles credentials, and whether syncing skills from a URL is safe."
 ---
 
 **When you need this:** You want to know what Kasetto can modify on disk, how it handles credentials, and whether syncing from URLs is safe.

--- a/site/content/docs/sharing-instructions.mdx
+++ b/site/content/docs/sharing-instructions.mdx
@@ -1,0 +1,152 @@
+---
+title: "Sharing Instructions Across Repos"
+description: "Keep one CLAUDE.md, AGENTS.md, and .cursor/rules in sync across every repository and agent, without copy-paste or symlinks."
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+**When you need this:** You have coding conventions in a `CLAUDE.md`, `AGENTS.md`, or
+`.cursor/rules` and you want the same rules in every repository, on every machine, for every agent
+you use.
+
+## The Drift Problem
+
+Instruction files are per-repository by design. Once you work in more than one repo, the copies
+diverge: you fix a rule in one project's `CLAUDE.md` and the other four keep the old wording. Add a
+second agent and it doubles, because Cursor wants `.cursor/rules/*.mdc` while Claude Code wants
+`CLAUDE.md` and Codex wants `AGENTS.md`.
+
+Symlinking a shared file breaks down quickly. It cannot merge with the repo-specific content that
+belongs in the same file, it does not survive a fresh clone, and it has no notion of a version.
+
+Kasetto treats instructions as a synced asset kind, like skills and MCP servers. You write each rule
+once, and `kst sync` renders it into whatever shape each agent expects.
+
+## Publish Instructions in a Repo
+
+An instruction is Markdown with optional YAML frontmatter, living in the source's `instructions/`
+directory. Any Git repository works - a dedicated one, or a folder inside a repo you already have.
+
+```markdown
+---
+description: Comment punctuation rules.
+globs: ["**/*.rs", "**/*.ts"]
+alwaysApply: false
+---
+
+Code comments never end with a period. Docstrings keep normal sentence punctuation.
+```
+
+Nested directories namespace with `:`, so `instructions/house/security.md` is referenced as
+`house:security`.
+
+## Consume Them
+
+Point a `kasetto.yaml` at the source and name the instructions you want:
+
+```yaml
+agent:
+  - claude-code
+  - cursor
+  - codex
+
+instructions:
+  - source: https://github.com/your-org/agent-conventions
+    instructions:
+      - comment-punctuation
+      - house:security
+```
+
+Then sync:
+
+```bash
+kst sync
+```
+
+Or skip the hand-editing and let the CLI write the config for you:
+
+```bash
+kst add https://github.com/your-org/agent-conventions --instruction comment-punctuation
+```
+
+Use `instructions: "*"` to take everything the source publishes.
+
+## What Lands Where
+
+One instruction becomes a different artifact per agent. There are two destination shapes:
+
+| Shape | Example agents | Result |
+| --- | --- | --- |
+| Aggregate file | Claude Code, Codex, Gemini CLI, Copilot | All instructions merge into one shared `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` |
+| Per-instruction directory | Cursor, Windsurf, Cline, Roo Code | One file per instruction, e.g. `.cursor/rules/comment-punctuation.mdc` |
+
+Cursor is the only agent that gets reconstructed `description` / `globs` / `alwaysApply`
+frontmatter; the rest receive the Markdown body. The full per-agent table is in
+[supported agents](/docs/agents#instruction-destinations).
+
+## Your Own Edits Survive
+
+Aggregate files are shared with content you wrote yourself, so Kasetto wraps each instruction it
+installs in a managed comment block:
+
+```markdown
+<!-- kasetto:instruction:comment-punctuation -->
+Code comments never end with a period. Docstrings keep normal sentence punctuation.
+<!-- /kasetto:instruction:comment-punctuation -->
+```
+
+Everything outside those markers is left byte-for-byte alone. `kst remove` and `kst clean` strip
+only Kasetto's own blocks and never delete the file.
+
+<Callout type="tip">
+
+Run `kst sync --dry-run` the first time you point Kasetto at an existing `CLAUDE.md`. It reports
+every file it would touch without writing anything.
+
+</Callout>
+
+## Project or Global
+
+Scope decides whether the rules apply to one repository or to everything you open:
+
+```bash
+kst sync --project   # writes ./CLAUDE.md, ./.cursor/rules/
+kst sync --global    # writes ~/.claude/CLAUDE.md, ~/.cursor/rules/
+```
+
+Org-wide conventions usually belong in global scope, with repo-specific rules layered on top in
+project scope. Configs compose with `extends`, so a team base config can carry the shared set while
+each project adds its own - see [extending another config](/docs/configuration#extending-another-config).
+
+## Updating and Rolling Back
+
+A plain `kst sync` installs exactly what `kasetto.lock` pins. To pick up new wording from a moving
+branch:
+
+```bash
+kst sync --update
+```
+
+Pin `ref:` to a tag or commit when you want a rule set frozen, and commit `kasetto.lock` so everyone
+on the team renders the same instructions. To roll a change back, move the `ref:` and sync again.
+
+## Auditing and Removing
+
+See what is installed:
+
+```bash
+kst list --type instructions
+```
+
+`kst doctor` additionally reports orphaned instruction blocks left in a shared `CLAUDE.md` - useful
+after someone hand-edits a file Kasetto manages. To drop one:
+
+```bash
+kst remove https://github.com/your-org/agent-conventions --instruction house:security
+```
+
+## Next Steps
+
+- [Configuration reference](/docs/configuration#instruction-source-fields) - every field on an instruction source
+- [Supported agents](/docs/agents#instruction-destinations) - exact destination for all 22 agents
+- [Cookbook](/docs/cookbook) - team, monorepo, and multi-agent setups

--- a/site/content/docs/slash-commands.mdx
+++ b/site/content/docs/slash-commands.mdx
@@ -1,6 +1,6 @@
 ---
-title: Slash Commands
-description: Sync user-defined slash commands (prompt templates) across supported agents.
+title: "Slash Commands"
+description: "Share custom slash-commands and prompt templates across Claude Code, Cursor, Codex, and Gemini CLI from a single source."
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/site/content/docs/sync-flow.mdx
+++ b/site/content/docs/sync-flow.mdx
@@ -1,6 +1,6 @@
 ---
-title: Sync Flow
-description: Diagrams of the sync flow.
+title: "Sync Flow Diagrams"
+description: "Diagrams of how kst sync resolves sources, discovers assets, diffs the lock, and writes into each agent environment."
 ---
 
 Complete reference for how `kst sync` resolves sources, discovers skills, commands, instructions, and MCP files, diffs against the lock, and writes to agent environments.

--- a/site/content/docs/vs-alternatives.mdx
+++ b/site/content/docs/vs-alternatives.mdx
@@ -1,0 +1,102 @@
+---
+title: "Kasetto vs the Alternatives"
+description: "How Kasetto compares to Vercel Skills, Claude plugin marketplaces, dotfiles and symlinks, and copying files by hand."
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+**When you need this:** You are already managing AI agent config somehow and want to know whether
+Kasetto solves a problem you actually have.
+
+<Callout type="info">
+
+This page describes these tools as of August 2026. The space moves quickly - check each project's
+own documentation before making a decision.
+
+</Callout>
+
+## The Short Version
+
+Most tools in this space are **installers**: you run a command, a skill lands on disk, and the
+record of what you did is the disk itself. Kasetto is a **package manager**: the config declares
+what should exist, a lock file pins exactly what you got, and sync converges the disk to match.
+
+If you work in one repo, on one machine, with one agent, an installer is enough and Kasetto is
+overhead. The difference starts to matter at the second machine, the second agent, or the second
+teammate.
+
+## Compared to Vercel Skills
+
+[Vercel Skills](https://github.com/vercel-labs/skills) installs skills from a curated catalog. It is
+a good way to discover and try something quickly.
+
+The differences that matter:
+
+- **Source of truth.** With a catalog installer, the answer to "what is installed here" is whatever
+  is on disk. Kasetto's answer is `kasetto.yaml` plus `kasetto.lock`, both committable.
+- **Where skills come from.** Kasetto takes any Git URL or local path, including private and
+  self-hosted GitHub, GitLab, Bitbucket, Codeberg, and Gitea. There is no catalog to be accepted
+  into.
+- **Asset kinds.** Kasetto syncs skills, MCP servers, slash-commands, and instruction files from the
+  same source, not skills alone.
+
+## Compared to Claude Plugin Marketplaces
+
+Plugin marketplaces give Claude runtime integrations, installed and managed through the agent
+itself. They are the right tool when you want a capability inside one agent and you want that agent
+to own its lifecycle.
+
+Kasetto sits a layer below and is agent-agnostic. It writes files into the locations agents already
+read, so the same source lands in Claude Code, Cursor, Codex, and 19 others from one `kst sync`.
+The two compose - a marketplace plugin and a Kasetto-managed skill can coexist, because Kasetto
+never touches entries it did not install.
+
+## Compared to Dotfiles and Symlinks
+
+A dotfiles repo with symlinks is the honest DIY baseline, and for a single machine it works.
+
+Where it runs out:
+
+- **Merging.** A symlink replaces a file. It cannot merge shared rules into a `CLAUDE.md` that also
+  holds repo-specific content. Kasetto uses managed comment blocks so both survive in the same file.
+- **Per-agent formats.** Symlinking the same file into `.cursor/rules/` does not give Cursor the
+  MDC frontmatter it expects. Kasetto transforms each asset into the target's native format.
+- **Versioning.** Symlinks track your working copy, whatever state it is in. A lock file pins a
+  commit, so a teammate's clone renders exactly what yours does.
+- **Windows.** Symlinks need elevated permissions or developer mode; a static binary that copies
+  files does not.
+
+## Compared to Copying Files by Hand
+
+This is what most people actually do, and it works right up until the copies diverge. The failure is
+silent: one repo's conventions quietly go stale and the agent keeps confidently applying the old
+ones.
+
+## Feature Comparison
+
+| | Kasetto | Catalog installers | Plugin marketplaces | Dotfiles + symlinks |
+| --- | --- | --- | --- | --- |
+| Declarative config file | yes | no | no | partial |
+| Lock file with pinned commits | yes | no | no | no |
+| Multiple agents from one source | yes | no | no | manual |
+| Skills, MCPs, commands, instructions | yes | skills | varies | manual |
+| Arbitrary and private Git sources | yes | catalog | marketplace | yes |
+| Merges into existing files | yes | n/a | n/a | no |
+| Secret injection at sync time | yes | no | no | no |
+| Works offline from the lock | yes | no | no | yes |
+
+## When Not to Use Kasetto
+
+Being direct about this is more useful than a feature list:
+
+- **One repo, one agent, no team.** Copy the file. You do not need a lock file.
+- **You want runtime behavior inside one agent.** That is what plugins are for. Kasetto only moves
+  files into place; it never executes what it installs.
+- **Your skills are not in Git.** Kasetto reads Git repositories and local directories. If your
+  assets live somewhere else, there is nothing for it to resolve.
+
+## Next Steps
+
+- [What is Kasetto?](/docs) - the five-minute tour
+- [Cookbook](/docs/cookbook) - team, monorepo, and pinned-rollout setups
+- [How sync works](/docs/how-sync-works) - the lock contract and merge rules

--- a/site/content/docs/writing-skills.mdx
+++ b/site/content/docs/writing-skills.mdx
@@ -1,6 +1,6 @@
 ---
-title: Writing Skills
-description: Author skills that Kasetto can sync.
+title: "Writing Agent Skills"
+description: "Author and publish skills that Kasetto can sync into Claude Code, Cursor, and every other supported agent."
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/site/lib/markdown.ts
+++ b/site/lib/markdown.ts
@@ -1,18 +1,23 @@
 import meta from "@/content/docs/meta.json";
 import { source } from "@/lib/source";
 
-type Page = NonNullable<ReturnType<typeof source.getPage>>;
+export type Page = NonNullable<ReturnType<typeof source.getPage>>;
 
 const FRONTMATTER = /^---\n[\s\S]*?\n---\n/;
 const LEADING_MDX_IMPORTS = /^(import .+\n)+/;
 
-/** Raw MDX source for a docs page, as plain Markdown with frontmatter swapped for a heading. */
-export function getPageMarkdown(page: Page): string {
-  const body = page.data.content
+/** A docs page's Markdown body, with frontmatter and leading MDX imports removed. */
+export function getPageBody(page: Page): string {
+  return page.data.content
     .replace(FRONTMATTER, "")
     .trimStart()
     .replace(LEADING_MDX_IMPORTS, "")
     .trim();
+}
+
+/** Raw MDX source for a docs page, as plain Markdown with frontmatter swapped for a heading. */
+export function getPageMarkdown(page: Page): string {
+  const body = getPageBody(page);
   const heading = page.data.description
     ? `# ${page.data.title}\n\n${page.data.description}`
     : `# ${page.data.title}`;

--- a/site/lib/site.ts
+++ b/site/lib/site.ts
@@ -1,0 +1,9 @@
+/**
+ * Canonical origin for the site.
+ *
+ * The apex host is canonical: it is what the README and installer scripts
+ * publish (`curl -fsSL kasetto.dev/install | sh`), so `www` permanently
+ * redirects here. Every absolute URL the site emits - canonical tags, the
+ * sitemap, `llms.txt` links - must be built from this constant.
+ */
+export const SITE_URL = "https://kasetto.dev";

--- a/site/lib/structured-data.ts
+++ b/site/lib/structured-data.ts
@@ -1,0 +1,96 @@
+import { getPageBody, type Page } from "@/lib/markdown";
+import { SITE_URL } from "@/lib/site";
+
+/** Reduce inline Markdown to the plain prose search engines should read. */
+function toPlainText(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/[`*_>]/g, "")
+    .replace(/^\s*[-+]\s+/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** The product itself, for the homepage. */
+export function softwareApplicationJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: "Kasetto",
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "macOS, Linux, Windows",
+    url: SITE_URL,
+    downloadUrl: `${SITE_URL}/install`,
+    codeRepository: "https://github.com/pivoshenko/kasetto",
+    programmingLanguage: "Rust",
+    license: "https://github.com/pivoshenko/kasetto/blob/main/LICENSE-MIT",
+    description:
+      "A declarative AI agent environment manager. Syncs skills, MCP servers, slash-commands, and instructions from Git repositories into 22 AI coding agents.",
+    author: {
+      "@type": "Person",
+      name: "Volodymyr Pivoshenko",
+      url: "https://github.com/pivoshenko",
+    },
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+  };
+}
+
+/** Home → Documentation → page trail for a docs page. */
+export function breadcrumbJsonLd(page: Page) {
+  const trail = [
+    { name: "Kasetto", url: SITE_URL },
+    { name: "Documentation", url: `${SITE_URL}/docs` },
+  ];
+  if (page.url !== "/docs") {
+    trail.push({ name: page.data.title, url: `${SITE_URL}${page.url}` });
+  }
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: trail.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}
+
+/**
+ * FAQ rich-result markup derived from the page's own `##` sections.
+ *
+ * Every question and answer is already visible on the page, which is what
+ * Google requires - this only restates the existing structure.
+ */
+export function faqJsonLd(page: Page) {
+  const entries = getPageBody(page)
+    .split(/^## /m)
+    .slice(1)
+    .map((section) => {
+      const newline = section.indexOf("\n");
+      if (newline === -1) return null;
+      const question = toPlainText(section.slice(0, newline));
+      const answer = toPlainText(section.slice(newline));
+      return question && answer ? { question, answer } : null;
+    })
+    .filter((entry) => entry !== null);
+
+  if (entries.length === 0) return null;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: entries.map((entry) => ({
+      "@type": "Question",
+      name: entry.question,
+      acceptedAnswer: { "@type": "Answer", text: entry.answer },
+    })),
+  };
+}

--- a/site/next.config.mjs
+++ b/site/next.config.mjs
@@ -81,6 +81,15 @@ const nextConfig = {
           permanent: true,
         },
       ]),
+      // Everything else on the docs host, which otherwise serves the whole site
+      // a second time: /docs/<path>, /llms.txt, /sitemap.xml. Last, so the
+      // legacy bare-slug rules above still win.
+      {
+        source: "/:path*",
+        has: docsHost,
+        destination: "https://kasetto.dev/:path*",
+        permanent: true,
+      },
     ];
   },
 };

--- a/site/next.config.mjs
+++ b/site/next.config.mjs
@@ -13,7 +13,9 @@ const DOC_SLUGS = [
   "how-sync-works",
   "installation",
   "security",
+  "sharing-instructions",
   "sync-flow",
+  "vs-alternatives",
   "writing-skills",
 ];
 
@@ -36,6 +38,16 @@ const nextConfig = {
           },
         ],
       },
+      // The raw-Markdown mirrors duplicate every docs page verbatim. They exist
+      // for humans and LLM agents that fetch them directly, so keep them
+      // reachable but out of the index - otherwise each page competes with its
+      // own HTML twin.
+      ...["/docs-md/:path*", "/docs-md", "/docs/:path*.md", "/docs.md", "/llms-full.txt"].map(
+        (source) => ({
+          source,
+          headers: [{ key: "X-Robots-Tag", value: "noindex" }],
+        })
+      ),
     ];
   },
   async rewrites() {


### PR DESCRIPTION
# Pull Request Checklist

## Summary

- The site had **no `robots.txt` and no `sitemap.xml`** (both 404), **no canonical tags** on any page, and every docs page shipped an indexable raw-Markdown twin. Google had no crawl map and no way to resolve the duplicates, which is why the site drew 6 organic search visits in a fortnight and ranked for nothing but the brand name.
- Adopts the **apex host as canonical**. It is what the README and installer scripts already publish (`curl -fsSL kasetto.dev/install | sh`), so that command no longer takes a redirect hop. Every absolute URL now derives from one `SITE_URL` constant in `site/lib/site.ts`.
- Adds two pages for searches that had no landing page: a comparison against the alternatives, and a task-shaped guide to sharing instructions across repos - instructions were documented as reference but had no page of their own.

### What changed

| Area | Change |
| --- | --- |
| Crawlability | New `app/sitemap.ts` (18 URLs) and `app/robots.ts` |
| Canonicals | `alternates.canonical` on the homepage and every docs page |
| Duplicates | `X-Robots-Tag: noindex` on `/docs/*.md`, `/docs-md/*`, `llms-full.txt` |
| Duplicate host | `docs.kasetto.dev/*` now 308s to the apex; previously only bare legacy slugs redirected and `docs.kasetto.dev/docs/<slug>` served a full copy |
| Titles | Homepage was `<title>Kasetto</title>`; all 15 docs titles and descriptions rewritten for search intent |
| Structured data | `SoftwareApplication`, `BreadcrumbList`, and `FAQPage` (derived from the FAQ's own sections) |
| Social cards | Docs pages now carry per-page `og:` and `twitter:` tags with the card image |
| Link hygiene | README logo link and `Cargo.toml` `documentation` pointed at redirecting hosts |

### Requires a Vercel domain change to take effect

`kasetto.dev` currently **307s to `www.kasetto.dev`**, which is the reverse of what this branch declares. A canonical pointing at a redirecting URL is a signal Google may discard, so **before or alongside deploying**, swap the redirect in Vercel → project `kasetto-dev` → Settings → Domains:

1. Clear the redirect on `kasetto.dev` so it serves content.
2. Set `www.kasetto.dev` to redirect to `kasetto.dev` with a permanent **308**.

Order matters - doing (2) first while (1) still points at www creates a redirect loop.

Afterwards, verify `kasetto.dev` in Google Search Console and submit `https://kasetto.dev/sitemap.xml`.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors