### PR TITLE
feat(agent): add pi support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Kasetto is a declarative AI agent environment manager: a Rust CLI that syncs four asset kinds -
 **skills**, **slash-commands**, **MCP servers**, and **instructions** (`CLAUDE.md` / `AGENTS.md` /
-`.cursor/rules` / ...) - from git repos or local dirs into 22 agent environments, driven by a
+`.cursor/rules` / ...) - from git repos or local dirs into 23 agent environments, driven by a
 `kasetto.yaml` config and pinned by a `kasetto.lock`. Modeled on cargo/uv ergonomics.
 
 Two things live here:
@@ -72,13 +72,15 @@ style). Errors are a boxed `Box<dyn Error + Send + Sync>` (`error.rs`), no error
 - **Scope** (`model::resolve_scope`): `Project` or `Global`, resolved CLI flag -> config field ->
   default `Global`. It picks install paths *and* the lock location: `<project root>/kasetto.lock`
   for Project, `$XDG_DATA_HOME/kasetto/kasetto.lock` for Global.
-- **Agent as exhaustive enum** (`model/agent.rs`, 22 variants + `AGENT_PRESETS`): each variant maps
-  to skill dirs, command dirs, instruction destinations, and MCP settings targets, per scope.
+- **Agent as exhaustive enum** (`model/agent.rs`, 23 variants + `AGENT_PRESETS`): each variant maps
+  to skill dirs, command dirs, instruction destinations, and MCP settings targets where supported,
+  per scope.
   Adding an agent = new variant + entries in every path table + the `AGENT_PRESETS` array + the
   README agent table.
 - **Per-agent output formats**: `McpSettingsFormat` (5: McpServers, VsCodeServers, OpenCode,
-  CodexToml, ZCode), `CommandFormat` (5: MarkdownFrontmatter, MarkdownPlain, PromptMd, PromptFile,
-  GeminiToml), `InstructionFormat` (3: AggregateMarkdown, CursorMdc, PlainMarkdownDir). All three
+  CodexToml, ZCode), `CommandFormat` (6: MarkdownFrontmatter, MarkdownFlatFrontmatter,
+  MarkdownPlain, PromptMd, PromptFile, GeminiToml), `InstructionFormat` (3: AggregateMarkdown,
+  CursorMdc, PlainMarkdownDir). All three
   enums live in `model/mod.rs` alongside their `*Target` structs.
 - **Aggregate vs per-file instructions**: `AggregateMarkdown` merges many instructions into one
   shared file (`CLAUDE.md`, `AGENTS.md`, ...) using managed `<!-- kasetto:instruction:ID -->`
@@ -164,7 +166,8 @@ never let one reach `main`, or Rust's `Debug` formatter prints `Error: Custom { 
 
 ### Env vars the CLI reads
 
-`KASETTO_CONFIG`, `KASETTO_CACHE_DIR`, `KASETTO_NO_CACHE`, `NO_COLOR`, `CLICOLOR_FORCE`,
+`KASETTO_CONFIG`, `KASETTO_CACHE_DIR`, `KASETTO_NO_CACHE`, `PI_CODING_AGENT_DIR`, `NO_COLOR`,
+`CLICOLOR_FORCE`,
 XDG (`XDG_CONFIG_HOME` / `XDG_DATA_HOME` / `XDG_CACHE_HOME`, `HOME`, `APPDATA`),
 `KST_KEEPASS_PASSWORD`, and source auth tokens (`GITHUB_TOKEN`/`GH_TOKEN`, `GITLAB_TOKEN`,
 `CI_JOB_TOKEN`, `BITBUCKET_*`, `CODEBERG_TOKEN`/`GITEA_TOKEN`/`FORGEJO_TOKEN`).

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Set the `agent` field and Kasetto figures out where to put things.
 | OpenClaw       | `openclaw`       | `~/.openclaw/skills/`           |
 | OpenCode       | `opencode`       | `~/.config/opencode/skills/`    |
 | OpenHands      | `openhands`      | `~/.openhands/skills/`          |
+| Pi             | `pi`             | `~/.pi/agent/skills/`           |
 | Replit         | `replit`         | `~/.config/agents/skills/`      |
 | Roo Code       | `roo`            | `~/.roo/skills/`                |
 | Trae           | `trae`           | `~/.trae/skills/`               |
@@ -292,6 +293,9 @@ Set the `agent` field and Kasetto figures out where to put things.
 | ZCode          | `zcode`          | `~/.zcode/skills/`              |
 
 </details>
+
+Pi's preset syncs skills, prompt templates, and `AGENTS.md`. Pi intentionally has no native MCP
+support, so MCP sources are skipped for Pi and still sync to other selected agents that support MCP.
 
 Don't see your agent? Use the `destination` field to point at any path.
 

--- a/site/app/components/agents-grid.tsx
+++ b/site/app/components/agents-grid.tsx
@@ -19,6 +19,7 @@ const AGENTS = [
   { name: "OpenClaw", value: "openclaw" },
   { name: "OpenCode", value: "opencode" },
   { name: "OpenHands", value: "openhands" },
+  { name: "Pi", value: "pi" },
   { name: "Replit", value: "replit" },
   { name: "Roo Code", value: "roo" },
   { name: "Trae", value: "trae" },

--- a/site/app/llms.txt/route.ts
+++ b/site/app/llms.txt/route.ts
@@ -10,7 +10,7 @@ export function GET() {
 
   const body = `# Kasetto
 
-> A declarative AI agent environment manager. Syncs skills, MCP servers, slash-commands, and instructions from GitHub repos or local directories into 22 agent environments.
+> A declarative AI agent environment manager. Syncs skills, MCP servers, slash-commands, and instructions from GitHub repos or local directories into 23 agent environments.
 
 ## Docs
 

--- a/site/content/docs/agents.mdx
+++ b/site/content/docs/agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Supported Agents"
-description: "All 22 agents Kasetto syncs to - Claude Code, Cursor, Codex, Copilot, Windsurf, Gemini CLI and more - and where each expects its files."
+description: "All 23 agents Kasetto syncs to - Claude Code, Cursor, Codex, Pi, Copilot, Windsurf, Gemini CLI and more - and where each expects its files."
 ---
 
 Set the `agent` field in your [config](/docs/configuration) and Kasetto figures out where to put things. Each preset maps to the directory that agent expects.
@@ -25,12 +25,15 @@ Set the `agent` field in your [config](/docs/configuration) and Kasetto figures 
 | OpenClaw       | `openclaw`       | `~/.openclaw/skills/`           |
 | OpenCode       | `opencode`       | `~/.config/opencode/skills/`    |
 | OpenHands      | `openhands`      | `~/.openhands/skills/`          |
+| Pi             | `pi`             | `~/.pi/agent/skills/`           |
 | Replit         | `replit`         | `~/.config/agents/skills/`      |
 | Roo Code       | `roo`            | `~/.roo/skills/`                |
 | Trae           | `trae`           | `~/.trae/skills/`               |
 | Warp           | `warp`           | `~/.agents/skills/`             |
 | Windsurf       | `windsurf`       | `~/.codeium/windsurf/skills/`   |
 | ZCode          | `zcode`          | `~/.zcode/skills/`              |
+
+Pi's global paths honor `PI_CODING_AGENT_DIR` when it overrides the default `~/.pi/agent` root.
 
 ## Instruction Destinations
 
@@ -54,6 +57,7 @@ file per instruction) are noted below; project paths are relative to the repo ro
 | Replit         | `replit.md`                          | -                                              | aggregate |
 | OpenHands      | `.openhands/microagents/repo.md`     | -                                              | aggregate |
 | ZCode          | `AGENTS.md`                          | `~/.zcode/AGENTS.md`                           | aggregate |
+| Pi             | `AGENTS.md`                          | `~/.pi/agent/AGENTS.md`                        | aggregate |
 | OpenClaw       | - (no project instructions)                 | `~/.openclaw/workspace/AGENTS.md`              | aggregate |
 | Cursor         | `.cursor/rules/<name>.mdc`           | `~/.cursor/rules/<name>.mdc`                    | directory (MDC) |
 | Windsurf       | `.windsurf/rules/<name>.md`          | `~/.codeium/windsurf/memories/global_rules.md` | directory / global aggregate |
@@ -68,6 +72,9 @@ Only Cursor (`.cursor/rules/*.mdc`) gets reconstructed `description`/`globs`/`al
 frontmatter; every other agent receives the Markdown body. Many of these agents also read the
 cross-tool `AGENTS.md` standard as a fallback. See the
 [instruction source reference](/docs/configuration#instruction-source-fields) for how instructions are transformed and merged.
+
+Pi intentionally has no native MCP support, so Kasetto skips MCP sources for the `pi` preset. In a
+multi-agent config, those sources are still merged into every selected agent that supports MCP.
 
 ## Custom Paths
 

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -164,8 +164,9 @@ Paths are resolved relative to the source root; absolute paths are honored as-is
 
 
 MCP config files must contain a `mcpServers` object with server definitions. Servers are merged
-into each agent's native settings file (e.g., `.claude.json` for Claude Code, `.cursor/mcp.json`
-for Cursor). See [how sync works](/docs/how-sync-works) for merge behavior details.
+into each selected agent's native settings file when that agent supports MCP (e.g., `.claude.json`
+for Claude Code, `.cursor/mcp.json` for Cursor). Pi intentionally has no native MCP support, so the
+`pi` preset skips MCP sources. See [how sync works](/docs/how-sync-works) for merge behavior details.
 
 A pack can reference secrets with `${kst_<name>}` placeholders (tokens, passwords, API keys) instead
 of committing them. They're resolved at sync time from the environment or a credentials file. See
@@ -296,7 +297,7 @@ The value does not have to be a URL. An absolute local path works too, which is 
 
 ## Multiple Agents
 
-The `agent` field accepts a single value or a list. With a list, Kasetto installs skills, commands, and instructions to every agent's directory and merges MCPs into every agent's settings file:
+The `agent` field accepts a single value or a list. With a list, Kasetto installs each asset into every selected agent that supports that asset type:
 
 ```yaml
 agent:
@@ -337,3 +338,4 @@ These environment variables affect Kasetto's behavior:
 | `CLICOLOR_FORCE`  | Forces color even when stdout is not a TTY. Set automatically by `--color always`.              |
 | `KASETTO_CONFIG`  | Overrides config discovery to use the exact path or URL (see [Configuration](#configuration)).  |
 | `KASETTO_NO_CACHE`| Disables the on-disk source cache, forcing a fresh download + extract on every fetch. Set to any value. |
+| `PI_CODING_AGENT_DIR` | Overrides Pi's global resource root (default `~/.pi/agent`), matching Pi's native environment variable. |

--- a/site/content/docs/how-sync-works.mdx
+++ b/site/content/docs/how-sync-works.mdx
@@ -60,7 +60,9 @@ Kasetto auto-discovers MCP pack files in the source:
 
 Each file must contain a `mcpServers` JSON object. Use a `mcps:` list to pick specific files instead of discovering all.
 
-Server entries are merged into each agent's native settings file (e.g., `.claude.json`, `.cursor/mcp.json`). The merge follows two rules:
+Server entries are merged into each selected agent's native settings file (e.g., `.claude.json`,
+`.cursor/mcp.json`) when that agent supports MCP. Pi intentionally has no native MCP support, so
+Kasetto skips MCP sources for the `pi` preset. The merge follows two rules:
 
 1. **New entries are added.** If the settings file doesn't have a server with that name, it's
    inserted.

--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "What is Kasetto?"
-description: "Kasetto keeps AI agent skills, MCP servers, slash-commands, and instructions in one version-controlled YAML file and syncs them to 22 agents."
+description: "Kasetto keeps AI agent skills, MCP servers, slash-commands, and instructions in one version-controlled YAML file and syncs them to 23 agents."
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/site/content/docs/sharing-instructions.mdx
+++ b/site/content/docs/sharing-instructions.mdx
@@ -148,5 +148,5 @@ kst remove https://github.com/your-org/agent-conventions --instruction house:sec
 ## Next Steps
 
 - [Configuration reference](/docs/configuration#instruction-source-fields) - every field on an instruction source
-- [Supported agents](/docs/agents#instruction-destinations) - exact destination for all 22 agents
+- [Supported agents](/docs/agents#instruction-destinations) - exact destination for all 23 agents
 - [Cookbook](/docs/cookbook) - team, monorepo, and multi-agent setups

--- a/site/content/docs/slash-commands.mdx
+++ b/site/content/docs/slash-commands.mdx
@@ -71,6 +71,7 @@ Kasetto rewrites each command into the format expected by the destination agent:
 | openhands       | -                                      | `.openhands/microagents/` | Markdown + frontmatter |
 | codex           | `~/.codex/prompts/`                    | -                      | Markdown + frontmatter  |
 | gemini-cli      | `~/.gemini/commands/`                  | `.gemini/commands/`    | TOML                    |
+| pi              | `~/.pi/agent/prompts/`                 | `.pi/prompts/`         | Markdown + frontmatter  |
 | zcode           | `~/.zcode/commands/`                   | `.zcode/commands/`     | Markdown + frontmatter  |
 
 Agents not listed (antigravity, warp, replit, openclaw, trae, kiro-cli, goose) are

--- a/site/content/docs/vs-alternatives.mdx
+++ b/site/content/docs/vs-alternatives.mdx
@@ -47,7 +47,7 @@ itself. They are the right tool when you want a capability inside one agent and 
 to own its lifecycle.
 
 Kasetto sits a layer below and is agent-agnostic. It writes files into the locations agents already
-read, so the same source lands in Claude Code, Cursor, Codex, and 19 others from one `kst sync`.
+read, so the same source lands in Claude Code, Cursor, Codex, and 20 others from one `kst sync`.
 The two compose - a marketplace plugin and a Kasetto-managed skill can coexist, because Kasetto
 never touches entries it did not install.
 

--- a/site/lib/structured-data.ts
+++ b/site/lib/structured-data.ts
@@ -25,7 +25,7 @@ export function softwareApplicationJsonLd() {
     programmingLanguage: "Rust",
     license: "https://github.com/pivoshenko/kasetto/blob/main/LICENSE-MIT",
     description:
-      "A declarative AI agent environment manager. Syncs skills, MCP servers, slash-commands, and instructions from Git repositories into 22 AI coding agents.",
+      "A declarative AI agent environment manager. Syncs skills, MCP servers, slash-commands, and instructions from Git repositories into 23 AI coding agents.",
     author: {
       "@type": "Person",
       name: "Volodymyr Pivoshenko",

--- a/src/commands/sync/mcps.rs
+++ b/src/commands/sync/mcps.rs
@@ -58,9 +58,9 @@ pub(super) fn sync_mcps(
     let mut secrets_need_update = false;
     let mcp_settings_list = resolve_mcp_settings_targets(ctx.cfg, ctx.scope, ctx.cfg_dir)?;
 
-    // No agents configured (e.g. user dropped `agent:`) but lock still has MCP
-    // entries. Config is source of truth, so scrub the orphans from every
-    // known agent's settings file as best-effort, prune the lock, and return
+    // No configured agent has a native MCP target (e.g. no `agent:` or Pi only).
+    // Config is source of truth, so scrub any previously locked MCPs from every
+    // known target as best-effort, prune the lock, and return without fetching.
     if mcp_settings_list.is_empty() {
         let has_orphans = lock.assets.values().any(|a| a.kind == "mcp");
         if has_orphans {

--- a/src/commands/sync/mcps.rs
+++ b/src/commands/sync/mcps.rs
@@ -662,6 +662,47 @@ fn remove_stale(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fsops::temp_dir;
+    use crate::model::{Agent, AgentField, Config, McpSourceSpec};
+
+    fn mcp_cfg(src_root: &Path, agents: Vec<Agent>) -> Config {
+        Config {
+            destination: None,
+            scope: Some(Scope::Project),
+            agent: Some(AgentField::Many(agents)),
+            skills: Vec::new(),
+            mcps: vec![McpSourceSpec {
+                source: src_root.to_string_lossy().to_string(),
+                branch: None,
+                git_ref: None,
+                mcps: McpsField::Wildcard("*".into()),
+            }],
+            commands: Vec::new(),
+            instructions: Vec::new(),
+            secrets: None,
+        }
+    }
+
+    fn project_ctx<'a>(cfg: &'a Config, project: &'a PathBuf) -> SyncContext<'a> {
+        SyncContext {
+            cfg,
+            cfg_dir: project,
+            destinations: std::slice::from_ref(project),
+            scope_root: project.clone(),
+            scope: Scope::Project,
+            dry_run: false,
+            animate: false,
+            plain: true,
+            update: false,
+            update_only: Vec::new(),
+            locked: false,
+            secrets: crate::secrets::SecretContext::empty(),
+        }
+    }
+
+    fn project_mcp_settings(project: &Path) -> serde_json::Value {
+        serde_json::from_str(&fs::read_to_string(project.join(".mcp.json")).unwrap()).unwrap()
+    }
 
     #[test]
     fn pending_mcp_classification_new_vs_update() {
@@ -722,6 +763,64 @@ mod tests {
             !update_only.iter().any(|p| p.is_new),
             "updates should not trigger the gate"
         );
+    }
+
+    #[test]
+    fn reconfig_from_mixed_pi_to_pi_only_prunes_installed_mcp() {
+        let src_root = temp_dir("kasetto-mcp-pi-src");
+        fs::create_dir_all(&src_root).unwrap();
+        fs::write(
+            src_root.join("mcp.json"),
+            r#"{"mcpServers":{"managed":{"command":"echo"}}}"#,
+        )
+        .unwrap();
+        let project = temp_dir("kasetto-mcp-pi-project");
+        fs::create_dir_all(&project).unwrap();
+        fs::write(
+            project.join(".mcp.json"),
+            r#"{"mcpServers":{"user-owned":{"command":"keep"}}}"#,
+        )
+        .unwrap();
+
+        let mixed_cfg = mcp_cfg(&src_root, vec![Agent::Pi, Agent::ClaudeCode]);
+        let mut lock = LockFile::default();
+        let mut summary = Summary::default();
+        let mut actions = Vec::new();
+        sync_mcps(
+            &project_ctx(&mixed_cfg, &project),
+            &mut lock,
+            &mut summary,
+            &mut actions,
+        )
+        .unwrap();
+
+        assert_eq!(summary.installed, 1);
+        let settings = project_mcp_settings(&project);
+        assert!(settings["mcpServers"]["managed"].is_object());
+        assert!(settings["mcpServers"]["user-owned"].is_object());
+        assert_eq!(lock.assets.values().filter(|a| a.kind == "mcp").count(), 1);
+
+        // Pi has no MCP target, so this transition must prune the prior managed
+        // server without reading the still-configured source or touching user data.
+        fs::remove_dir_all(&src_root).unwrap();
+        let pi_cfg = mcp_cfg(&src_root, vec![Agent::Pi]);
+        let mut summary2 = Summary::default();
+        let mut actions2 = Vec::new();
+        sync_mcps(
+            &project_ctx(&pi_cfg, &project),
+            &mut lock,
+            &mut summary2,
+            &mut actions2,
+        )
+        .unwrap();
+
+        assert_eq!(summary2.removed, 1);
+        let settings = project_mcp_settings(&project);
+        assert!(settings["mcpServers"].get("managed").is_none());
+        assert!(settings["mcpServers"]["user-owned"].is_object());
+        assert_eq!(lock.assets.values().filter(|a| a.kind == "mcp").count(), 0);
+
+        let _ = fs::remove_dir_all(&project);
     }
 
     #[test]

--- a/src/fsops/mod.rs
+++ b/src/fsops/mod.rs
@@ -149,7 +149,7 @@ pub(crate) fn resolve_destinations(
     }
 }
 
-/// Returns one MCP settings path per configured agent, respecting scope.
+/// Returns one MCP settings path per MCP-capable configured agent, respecting scope.
 pub(crate) fn resolve_mcp_settings_targets(
     cfg: &Config,
     scope: Scope,
@@ -164,9 +164,10 @@ pub(crate) fn resolve_mcp_settings_targets(
     match scope {
         Scope::Project => {
             for a in agents {
-                let t = a.mcp_project_target(project_root);
-                if seen.insert(t.path.clone()) {
-                    out.push(t);
+                if let Some(t) = a.mcp_project_target(project_root) {
+                    if seen.insert(t.path.clone()) {
+                        out.push(t);
+                    }
                 }
             }
         }
@@ -174,9 +175,10 @@ pub(crate) fn resolve_mcp_settings_targets(
             let home = dirs_home()?;
             let kasetto_config = dirs_kasetto_config()?;
             for a in agents {
-                let t = a.mcp_settings_target(&home, &kasetto_config);
-                if seen.insert(t.path.clone()) {
-                    out.push(t);
+                if let Some(t) = a.mcp_settings_target(&home, &kasetto_config) {
+                    if seen.insert(t.path.clone()) {
+                        out.push(t);
+                    }
                 }
             }
         }

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -263,7 +263,7 @@ fn pi_agent_dir(home: &Path) -> PathBuf {
 }
 
 fn pi_agent_dir_from(home: &Path, configured: Option<&OsStr>) -> PathBuf {
-    let Some(configured) = configured else {
+    let Some(configured) = configured.filter(|value| !value.is_empty()) else {
         return home.join(".pi/agent");
     };
     let configured = Path::new(configured);
@@ -860,6 +860,10 @@ mod tests {
     fn pi_agent_dir_honors_native_override_shape() {
         let home = Path::new("/tmp/home");
         assert_eq!(pi_agent_dir_from(home, None), home.join(".pi/agent"));
+        assert_eq!(
+            pi_agent_dir_from(home, Some(OsStr::new(""))),
+            home.join(".pi/agent")
+        );
         assert_eq!(
             pi_agent_dir_from(home, Some(OsStr::new("~/custom-pi"))),
             home.join("custom-pi")

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -1,6 +1,7 @@
 //! Module that contains the supported agent registry and its per-asset destinations and formats.
 
 use serde::{Deserialize, Serialize};
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use super::{
@@ -49,6 +50,8 @@ pub(crate) enum Agent {
     OpenCode,
     #[serde(rename = "openhands")]
     OpenHands,
+    #[serde(rename = "pi")]
+    Pi,
     #[serde(rename = "replit")]
     Replit,
     #[serde(rename = "roo")]
@@ -81,6 +84,7 @@ pub(crate) const AGENT_PRESETS: &[Agent] = &[
     Agent::OpenClaw,
     Agent::OpenCode,
     Agent::OpenHands,
+    Agent::Pi,
     Agent::Replit,
     Agent::Roo,
     Agent::Trae,
@@ -89,7 +93,7 @@ pub(crate) const AGENT_PRESETS: &[Agent] = &[
     Agent::ZCode,
 ];
 
-/// Deduped native MCP config files for every known agent (for `clean` manifest wipe).
+/// Deduped native MCP config files for every known MCP-capable agent.
 pub(crate) fn all_mcp_settings_targets(
     home: &Path,
     kasetto_config: &Path,
@@ -101,7 +105,7 @@ pub(crate) fn all_mcp_settings_targets(
     )
 }
 
-/// Deduped project-level MCP config files for every known agent (for `clean` in project scope).
+/// Deduped project MCP config files for every known MCP-capable agent.
 pub(crate) fn all_mcp_project_targets(project_root: &Path) -> Vec<McpSettingsTarget> {
     dedup_targets(
         AGENT_PRESETS
@@ -119,8 +123,8 @@ fn dedup_by_path<T>(iter: impl Iterator<Item = T>, key: impl Fn(&T) -> &Path) ->
     out
 }
 
-fn dedup_targets(iter: impl Iterator<Item = McpSettingsTarget>) -> Vec<McpSettingsTarget> {
-    dedup_by_path(iter, |t| t.path.as_path())
+fn dedup_targets(iter: impl Iterator<Item = Option<McpSettingsTarget>>) -> Vec<McpSettingsTarget> {
+    dedup_by_path(iter.flatten(), |t| t.path.as_path())
 }
 
 fn dedup_command_targets(iter: impl Iterator<Item = Option<CommandTarget>>) -> Vec<CommandTarget> {
@@ -219,7 +223,7 @@ pub(crate) fn all_instruction_project_targets(project_root: &Path) -> Vec<Instru
     )
 }
 
-/// Deduped global MCP settings files for a specific set of agents.
+/// Deduped global MCP settings files for the MCP-capable agents in a set.
 pub(crate) fn mcp_settings_targets(home: &Path, agents: &[Agent]) -> Vec<McpSettingsTarget> {
     dedup_targets(
         agents
@@ -228,7 +232,7 @@ pub(crate) fn mcp_settings_targets(home: &Path, agents: &[Agent]) -> Vec<McpSett
     )
 }
 
-/// Deduped project-level MCP settings files for a specific set of agents.
+/// Deduped project MCP settings files for the MCP-capable agents in a set.
 pub(crate) fn mcp_settings_project_targets(
     project_root: &Path,
     agents: &[Agent],
@@ -250,6 +254,26 @@ fn instruction(base: &Path, rel: &str, format: InstructionFormat) -> Option<Inst
         path: base.join(rel),
         format,
     })
+}
+
+/// Pi's user resources share a configurable root. Keep Kasetto aligned with
+/// Pi's `PI_CODING_AGENT_DIR` handling, including leading-tilde expansion.
+fn pi_agent_dir(home: &Path) -> PathBuf {
+    pi_agent_dir_from(home, std::env::var_os("PI_CODING_AGENT_DIR").as_deref())
+}
+
+fn pi_agent_dir_from(home: &Path, configured: Option<&OsStr>) -> PathBuf {
+    let Some(configured) = configured else {
+        return home.join(".pi/agent");
+    };
+    let configured = Path::new(configured);
+    if configured == Path::new("~") {
+        return home.to_path_buf();
+    }
+    match configured.strip_prefix("~") {
+        Ok(rest) => home.join(rest),
+        Err(_) => configured.to_path_buf(),
+    }
 }
 
 /// VS Code / Copilot user-profile `mcp.json` (not Insiders).
@@ -292,6 +316,7 @@ impl Agent {
             Agent::OpenClaw => home.join(".openclaw/skills"),
             Agent::OpenCode => home.join(".config/opencode/skills"),
             Agent::OpenHands => home.join(".openhands/skills"),
+            Agent::Pi => pi_agent_dir(home).join("skills"),
             Agent::Roo => home.join(".roo/skills"),
             Agent::Trae => home.join(".trae/skills"),
             Agent::Windsurf => home.join(".codeium/windsurf/skills"),
@@ -299,13 +324,13 @@ impl Agent {
         }
     }
 
-    /// Native MCP config location and merge format for this agent.
+    /// Native MCP config location and merge format, if the agent supports MCP.
     pub(crate) fn mcp_settings_target(
         self,
         home: &Path,
         _kasetto_config: &Path,
-    ) -> McpSettingsTarget {
-        match self {
+    ) -> Option<McpSettingsTarget> {
+        Some(match self {
             Agent::ClaudeCode => mcp_servers_target(home, ".claude.json"),
             Agent::Cursor => mcp_servers_target(home, ".cursor/mcp.json"),
             Agent::GithubCopilot => McpSettingsTarget {
@@ -336,12 +361,15 @@ impl Agent {
                 format: McpSettingsFormat::OpenCode,
             },
             Agent::OpenHands => mcp_servers_target(home, ".openhands/mcp.json"),
+            // Pi intentionally has no native MCP support. Third-party extensions
+            // own their configuration, so Kasetto must not invent a target.
+            Agent::Pi => return None,
             Agent::Trae => mcp_servers_target(home, ".trae/mcp.json"),
             Agent::ZCode => McpSettingsTarget {
                 path: home.join(".zcode/cli/config.json"),
                 format: McpSettingsFormat::ZCode,
             },
-        }
+        })
     }
 
     /// Project-local skills directory for this agent, relative to `project_root`.
@@ -362,6 +390,7 @@ impl Agent {
             Agent::OpenClaw => project_root.join(".openclaw/skills"),
             Agent::OpenCode => project_root.join(".opencode/skills"),
             Agent::OpenHands => project_root.join(".openhands/skills"),
+            Agent::Pi => project_root.join(".pi/skills"),
             Agent::Roo => project_root.join(".roo/skills"),
             Agent::Trae => project_root.join(".trae/skills"),
             Agent::Windsurf => project_root.join(".windsurf/skills"),
@@ -369,9 +398,9 @@ impl Agent {
         }
     }
 
-    /// Project-local MCP config location and merge format for this agent.
-    pub(crate) fn mcp_project_target(self, project_root: &Path) -> McpSettingsTarget {
-        match self {
+    /// Project-local MCP config location and merge format, if the agent supports MCP.
+    pub(crate) fn mcp_project_target(self, project_root: &Path) -> Option<McpSettingsTarget> {
+        Some(match self {
             Agent::ClaudeCode => McpSettingsTarget {
                 path: project_root.join(".mcp.json"),
                 format: McpSettingsFormat::McpServers,
@@ -404,6 +433,7 @@ impl Agent {
                 path: project_root.join(".zcode/config.json"),
                 format: McpSettingsFormat::ZCode,
             },
+            Agent::Pi => return None,
             Agent::Antigravity
             | Agent::Augment
             | Agent::Goose
@@ -411,7 +441,7 @@ impl Agent {
             | Agent::OpenHands
             | Agent::Replit
             | Agent::Warp => mcp_servers_target(project_root, ".mcp.json"),
-        }
+        })
     }
 
     /// Global commands directory and write format for this agent, if supported.
@@ -427,6 +457,11 @@ impl Agent {
                 home,
                 ".config/opencode/commands",
                 CommandFormat::MarkdownFrontmatter,
+            ),
+            Agent::Pi => cmd(
+                &pi_agent_dir(home),
+                "prompts",
+                CommandFormat::MarkdownFlatFrontmatter,
             ),
             Agent::Continue => cmd(home, ".continue/prompts", CommandFormat::PromptFile),
             Agent::Amp => cmd(
@@ -485,6 +520,11 @@ impl Agent {
                 project_root,
                 ".opencode/commands",
                 CommandFormat::MarkdownFrontmatter,
+            ),
+            Agent::Pi => cmd(
+                project_root,
+                ".pi/prompts",
+                CommandFormat::MarkdownFlatFrontmatter,
             ),
             Agent::Continue => cmd(project_root, ".continue/prompts", CommandFormat::PromptFile),
             Agent::GithubCopilot => cmd(project_root, ".github/prompts", CommandFormat::PromptMd),
@@ -548,6 +588,7 @@ impl Agent {
             Agent::Codex => instruction(project_root, "AGENTS.md", Agg),
             Agent::OpenCode => instruction(project_root, "AGENTS.md", Agg),
             Agent::Amp => instruction(project_root, "AGENTS.md", Agg),
+            Agent::Pi => instruction(project_root, "AGENTS.md", Agg),
             // Antigravity's native file is GEMINI.md (takes precedence over AGENTS.md)
             Agent::Antigravity => instruction(project_root, "GEMINI.md", Agg),
             Agent::GeminiCli => instruction(project_root, "GEMINI.md", Agg),
@@ -596,6 +637,7 @@ impl Agent {
             Agent::Junie => instruction(home, ".junie/AGENTS.md", Agg),
             Agent::OpenCode => instruction(home, ".config/opencode/AGENTS.md", Agg),
             Agent::Amp => instruction(home, ".config/amp/AGENTS.md", Agg),
+            Agent::Pi => instruction(&pi_agent_dir(home), "AGENTS.md", Agg),
             Agent::Goose => instruction(home, ".config/goose/.goosehints", Agg),
             Agent::GithubCopilot => instruction(home, ".copilot/copilot-instructions.md", Agg),
             Agent::OpenClaw => instruction(home, ".openclaw/workspace/AGENTS.md", Agg),
@@ -761,11 +803,13 @@ mod tests {
             Agent::ZCode.commands_project_path(pr).unwrap().format,
             CommandFormat::MarkdownFrontmatter
         );
-        let mcp = Agent::ZCode.mcp_settings_target(home, Path::new(""));
+        let mcp = Agent::ZCode
+            .mcp_settings_target(home, Path::new(""))
+            .unwrap();
         assert_eq!(mcp.path, home.join(".zcode/cli/config.json"));
         assert_eq!(mcp.format, McpSettingsFormat::ZCode);
         assert_eq!(
-            Agent::ZCode.mcp_project_target(pr).path,
+            Agent::ZCode.mcp_project_target(pr).unwrap().path,
             pr.join(".zcode/config.json")
         );
         assert_eq!(
@@ -775,6 +819,54 @@ mod tests {
         assert_eq!(
             Agent::ZCode.instructions_project_path(pr).unwrap().path,
             pr.join("AGENTS.md")
+        );
+    }
+
+    #[test]
+    fn pi_paths_and_formats() {
+        let home = Path::new("/tmp/home");
+        let pr = Path::new("/work");
+        let global_root = pi_agent_dir(home);
+
+        assert_eq!(Agent::Pi.global_path(home), global_root.join("skills"));
+        assert_eq!(Agent::Pi.project_path(pr), pr.join(".pi/skills"));
+        let global_command = Agent::Pi.commands_global_path(home).unwrap();
+        assert_eq!(global_command.path, global_root.join("prompts"));
+        assert_eq!(
+            global_command.format,
+            CommandFormat::MarkdownFlatFrontmatter
+        );
+        let project_command = Agent::Pi.commands_project_path(pr).unwrap();
+        assert_eq!(project_command.path, pr.join(".pi/prompts"));
+        assert_eq!(
+            project_command.format,
+            CommandFormat::MarkdownFlatFrontmatter
+        );
+        assert_eq!(
+            Agent::Pi.instructions_global_path(home).unwrap().path,
+            global_root.join("AGENTS.md")
+        );
+        assert_eq!(
+            Agent::Pi.instructions_project_path(pr).unwrap().path,
+            pr.join("AGENTS.md")
+        );
+        assert!(Agent::Pi.mcp_settings_target(home, Path::new("")).is_none());
+        assert!(Agent::Pi.mcp_project_target(pr).is_none());
+        assert!(mcp_settings_targets(home, &[Agent::Pi]).is_empty());
+        assert_eq!(serde_yaml::from_str::<Agent>("pi").unwrap(), Agent::Pi);
+    }
+
+    #[test]
+    fn pi_agent_dir_honors_native_override_shape() {
+        let home = Path::new("/tmp/home");
+        assert_eq!(pi_agent_dir_from(home, None), home.join(".pi/agent"));
+        assert_eq!(
+            pi_agent_dir_from(home, Some(OsStr::new("~/custom-pi"))),
+            home.join("custom-pi")
+        );
+        assert_eq!(
+            pi_agent_dir_from(home, Some(OsStr::new("relative-pi"))),
+            PathBuf::from("relative-pi")
         );
     }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -52,6 +52,8 @@ pub(crate) struct McpSettingsTarget {
 pub(crate) enum CommandFormat {
     /// Verbatim Markdown with YAML frontmatter (Claude Code style).
     MarkdownFrontmatter,
+    /// Flat `<name>.md` with YAML frontmatter preserved (Pi prompt templates).
+    MarkdownFlatFrontmatter,
     /// Markdown body only, frontmatter stripped.
     MarkdownPlain,
     /// `<name>.prompt.md`, frontmatter preserved (GitHub Copilot).

--- a/src/prompts/transform.rs
+++ b/src/prompts/transform.rs
@@ -8,12 +8,14 @@ use crate::model::{CommandFormat, CommandTarget};
 
 /// Returns the on-disk relative filename for a command, given its name and format.
 ///
-/// Namespaced names with `:` map to nested subdirectories for formats that keep
-/// the original Markdown shape. Plain formats flatten namespaces with `-`.
+/// Namespaced names with `:` map to nested subdirectories only where the agent
+/// scans recursively. Flat formats replace namespace separators with `-`.
 fn derive_relpath(name: &str, format: CommandFormat) -> PathBuf {
     match format {
         CommandFormat::MarkdownFrontmatter => name_to_nested_path(name, "md"),
-        CommandFormat::MarkdownPlain => PathBuf::from(format!("{}.md", flatten_name(name))),
+        CommandFormat::MarkdownFlatFrontmatter | CommandFormat::MarkdownPlain => {
+            PathBuf::from(format!("{}.md", flatten_name(name)))
+        }
         CommandFormat::PromptMd => PathBuf::from(format!("{}.prompt.md", flatten_name(name))),
         CommandFormat::PromptFile => PathBuf::from(format!("{}.prompt", flatten_name(name))),
         CommandFormat::GeminiToml => PathBuf::from(format!("{}.toml", flatten_name(name))),
@@ -40,7 +42,9 @@ fn flatten_name(name: &str) -> String {
 /// Render `parsed` to bytes for the given `format`.
 pub(crate) fn render(parsed: &Parsed, format: CommandFormat) -> String {
     match format {
-        CommandFormat::MarkdownFrontmatter | CommandFormat::PromptMd => {
+        CommandFormat::MarkdownFrontmatter
+        | CommandFormat::MarkdownFlatFrontmatter
+        | CommandFormat::PromptMd => {
             if let Some(fm) = &parsed.frontmatter {
                 format!("---\n{}\n---\n{}", fm, parsed.body)
             } else {
@@ -136,6 +140,10 @@ mod tests {
     #[test]
     fn flat_names_for_other_formats() {
         assert_eq!(
+            derive_relpath("git:commit", CommandFormat::MarkdownFlatFrontmatter),
+            PathBuf::from("git-commit.md")
+        );
+        assert_eq!(
             derive_relpath("git:commit", CommandFormat::MarkdownPlain),
             PathBuf::from("git-commit.md")
         );
@@ -159,6 +167,16 @@ mod tests {
         let rendered = render(&p, CommandFormat::MarkdownFrontmatter);
         assert!(rendered.starts_with("---\n"));
         assert!(rendered.contains("description: do thing"));
+        assert!(rendered.contains("Use $ARGUMENTS here."));
+    }
+
+    #[test]
+    fn flat_markdown_frontmatter_preserves_pi_metadata() {
+        let p = sample();
+        let rendered = render(&p, CommandFormat::MarkdownFlatFrontmatter);
+        assert!(rendered.starts_with("---\n"));
+        assert!(rendered.contains("description: do thing"));
+        assert!(rendered.contains("argument-hint: <n>"));
         assert!(rendered.contains("Use $ARGUMENTS here."));
     }
 

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -143,10 +143,8 @@ impl SecretContext {
     /// a required secret is missing (unless the policy is `warn`).
     pub(crate) fn inject_value(&self, value: &mut serde_json::Value) -> Result<()> {
         match value {
-            serde_json::Value::String(s) => {
-                if has_placeholder(s) {
-                    *s = self.substitute_str(s)?;
-                }
+            serde_json::Value::String(s) if has_placeholder(s) => {
+                *s = self.substitute_str(s)?;
             }
             serde_json::Value::Array(arr) => {
                 for v in arr.iter_mut() {


### PR DESCRIPTION
## Summary

- add first-class Pi presets for global and project skills, prompt templates, and `AGENTS.md`
- honor Pi's native `PI_CODING_AGENT_DIR` override and preserve prompt frontmatter while flattening namespaced templates
- skip MCP sources for Pi because the agent has no native MCP configuration, while retaining MCP sync for other selected agents
- document Pi across the README, agent reference, configuration guides, website agent grid, and generated metadata

## Testing

- `just check`
- local integration sync using the release binary: 117 skills installed into Pi and verified byte-for-byte against the Claude Code, Codex, and OpenCode destinations

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Non-obvious behavior is documented in code comments
- [x] Corresponding documentation is updated
- [x] Changes generate no new warnings or errors